### PR TITLE
🐛 Fix initial aspectRatio on Android #198

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -89,7 +89,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
             currentCaptureMode = CaptureModes.valueOf(captureMode),
             enableImageStream = enableImageStream,
             onStreamReady = { state -> state.updateLifecycle(activity!!) }).apply {
-            this.aspectRatio = if (aspectRatio == "RATIO_16_9") 1 else 0
+            this.updateAspectRatio(aspectRatio)
             this.flashMode = FlashMode.valueOf(flashMode)
         }
         orientationStreamListener =
@@ -466,13 +466,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
 
     override fun setAspectRatio(aspectRatio: String) {
         cameraState.apply {
-            // In CameraX, aspect ratio is an Int. RATIO_4_3 = 0 (default), RATIO_16_9 = 1
-            this.aspectRatio = if (aspectRatio == "RATIO_16_9") 1 else 0
-            this.rational = when (aspectRatio) {
-                "RATIO_16_9" -> Rational(9, 16)
-                "RATIO_1_1" -> Rational(1, 1)
-                else -> Rational(3, 4)
-            }
+            this.updateAspectRatio(aspectRatio)
             updateLifecycle(activity!!)
         }
     }

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
@@ -227,4 +227,14 @@ data class CameraXState(
             }
         }
     }
+
+    fun updateAspectRatio(newAspectRatio: String) {
+        // In CameraX, aspect ratio is an Int. RATIO_4_3 = 0 (default), RATIO_16_9 = 1
+        aspectRatio = if (newAspectRatio == "RATIO_16_9") 1 else 0
+        rational = when (newAspectRatio) {
+            "RATIO_16_9" -> Rational(9, 16)
+            "RATIO_1_1" -> Rational(1, 1)
+            else -> Rational(3, 4)
+        }
+    }
 }

--- a/android/src/main/kotlin/com/apparence/camerawesome/sensors/SensorOrientationListener.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/sensors/SensorOrientationListener.kt
@@ -9,8 +9,8 @@ class SensorOrientationListener : EventChannel.StreamHandler, SensorOrientation 
         this.events = events
     }
 
-    override fun onCancel(arguments: Any) {
-        events!!.endOfStream()
+    override fun onCancel(arguments: Any?) {
+        events?.endOfStream()
         events = null
     }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.0+1"
   characters:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

Fixes #198 
Initial aspectRatio was incorrectly set on Android.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*