### PR TITLE
Migrate integration tests to Patrol 1.0

### DIFF
--- a/example/android/app/src/androidTest/java/com/example/camera_app/MainActivityTest.java
+++ b/example/android/app/src/androidTest/java/com/example/camera_app/MainActivityTest.java
@@ -1,6 +1,5 @@
 package com.example.camera_app;
 
-
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import pl.leancode.patrol.PatrolTestRule;

--- a/example/integration_test/common.dart
+++ b/example/integration_test/common.dart
@@ -3,6 +3,19 @@ import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import 'package:patrol/patrol.dart';
 
+void patrol(
+  String description,
+  Future<void> Function(PatrolTester) callback, {
+  bool? skip,
+}) {
+  patrolTest(
+    description,
+    nativeAutomation: true,
+    skip: skip,
+    callback,
+  );
+}
+
 Future<void> allowPermissionsIfNeeded(PatrolTester $) async {
   if (await $.native.isPermissionDialogVisible()) {
     await $.native.grantPermissionWhenInUse();
@@ -19,8 +32,9 @@ Future<void> allowPermissionsIfNeeded(PatrolTester $) async {
 }
 
 Future<String> tempPath(String pictureName) async {
-  final file =
-      File('${(await getTemporaryDirectory()).path}/test/$pictureName');
+  final file = File(
+    '${(await getTemporaryDirectory()).path}/test/$pictureName',
+  );
   await file.create(recursive: true);
   return file.path;
 }

--- a/example/integration_test/config.dart
+++ b/example/integration_test/config.dart
@@ -1,8 +1,0 @@
-import 'package:patrol/patrol.dart';
-
-const patrolConfig = PatrolTesterConfig();
-
-const nativeAutomatorConfig = NativeAutomatorConfig(
-  packageName: 'com.example.camera_app',
-  bundleId: 'com.example.cameraApp',
-);

--- a/example/integration_test/photo_test.dart
+++ b/example/integration_test/photo_test.dart
@@ -4,10 +4,8 @@ import 'dart:io';
 import 'package:camera_app/drivable_camera.dart';
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:patrol/patrol.dart';
 
-import 'config.dart';
-import 'utils.dart';
+import 'common.dart';
 
 // To run it, you have to use `patrol drive` instead of `flutter test`.
 void main() {
@@ -16,11 +14,8 @@ void main() {
 
 void photoTests() {
   for (var sensor in Sensors.values) {
-    patrolTest(
+    patrol(
       'Take pictures > single picture ${sensor.name} camera',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true,
       ($) async {
         await $.pumpWidgetAndSettle(
           DrivableCamera(
@@ -42,11 +37,8 @@ void photoTests() {
       },
     );
 
-    patrolTest(
+    patrol(
       'Take pictures > multiple picture ${sensor.name} camera',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true,
       ($) async {
         int idxPicture = 0;
         const picturesToTake = 3;
@@ -78,11 +70,8 @@ void photoTests() {
     );
   }
 
-  patrolTest(
+  patrol(
     'Take pictures > One with ${Sensors.back} then one with ${Sensors.front}',
-    config: patrolConfig,
-    nativeAutomatorConfig: nativeAutomatorConfig,
-    nativeAutomation: true,
     ($) async {
       int idxSensor = 0;
       final sensors = [

--- a/example/integration_test/ui_test.dart
+++ b/example/integration_test/ui_test.dart
@@ -7,18 +7,13 @@ import 'package:camerawesome/pigeon.dart';
 import 'package:exif/exif.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:patrol/patrol.dart';
 
-import 'config.dart';
-import 'utils.dart';
+import 'common.dart';
 
 // To run it, you have to use `patrol drive` instead of `flutter test`.
 void main() {
-  patrolTest(
+  patrol(
     'UI > Photo and video mode',
-    config: patrolConfig,
-    nativeAutomatorConfig: nativeAutomatorConfig,
-    nativeAutomation: true,
     ($) async {
       await $.pumpWidgetAndSettle(
         DrivableCamera(
@@ -67,11 +62,8 @@ void main() {
     },
   );
 
-  patrolTest(
+  patrol(
     'UI > Photo mode elements',
-    config: patrolConfig,
-    nativeAutomatorConfig: nativeAutomatorConfig,
-    nativeAutomation: true,
     ($) async {
       await $.pumpWidgetAndSettle(
         DrivableCamera(
@@ -99,11 +91,8 @@ void main() {
     },
   );
 
-  patrolTest(
+  patrol(
     'UI > Video mode elements',
-    config: patrolConfig,
-    nativeAutomatorConfig: nativeAutomatorConfig,
-    nativeAutomation: true,
     ($) async {
       await $.pumpWidgetAndSettle(
         DrivableCamera(
@@ -167,190 +156,189 @@ void main() {
 
   // Back camera should have a flash and be able to switch between all flash modes
 
-  patrolTest('UI > Switching flash mode should work',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.photo(
-          pathBuilder: () => tempPath('single_photo_back.jpg'),
+  patrol(
+    'UI > Switching flash mode should work',
+    ($) async {
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.photo(
+            pathBuilder: () => tempPath('single_photo_back.jpg'),
+          ),
         ),
-      ),
-    );
+      );
 
-    await allowPermissionsIfNeeded($);
+      await allowPermissionsIfNeeded($);
 
-    // FLash off by default
-    expect(
-      find
-          .byType(Icon)
-          .evaluate()
-          .where(
-            (element) => (element.widget as Icon).icon == Icons.flash_off,
-          )
-          .length,
-      equals(1),
-    );
-    final flashButton = find.byType(AwesomeFlashButton);
-    await $.tester.tap(flashButton, warnIfMissed: false);
-    await $.pump(const Duration(milliseconds: 400));
-    // FLash auto next
-    expect(
-      find
-          .byType(Icon)
-          .evaluate()
-          .where(
-            (element) => (element.widget as Icon).icon == Icons.flash_auto,
-          )
-          .length,
-      equals(1),
-    );
-    await $.tester.tap(flashButton, warnIfMissed: false);
-    await $.pump(const Duration(milliseconds: 100));
-    // FLash on next
-    expect(
-      find
-          .byType(Icon)
-          .evaluate()
-          .where((element) => (element.widget as Icon).icon == Icons.flash_on)
-          .length,
-      equals(1),
-    );
-    await $.tester.tap(flashButton, warnIfMissed: false);
-    await $.pump(const Duration(milliseconds: 100));
-    // FLash always next
-    expect(
-      find
-          .byType(Icon)
-          .evaluate()
-          .where(
-            (element) => (element.widget as Icon).icon == Icons.flashlight_on,
-          )
-          .length,
-      equals(1),
-    );
-    await $.tester.tap(flashButton, warnIfMissed: false);
-    await $.pump(const Duration(milliseconds: 100));
-    // Back to flash none
-    expect(
-      find
-          .byType(Icon)
-          .evaluate()
-          .where(
-            (element) => (element.widget as Icon).icon == Icons.flash_off,
-          )
-          .length,
-      equals(1),
-    );
-  });
+      // FLash off by default
+      expect(
+        find
+            .byType(Icon)
+            .evaluate()
+            .where(
+              (element) => (element.widget as Icon).icon == Icons.flash_off,
+            )
+            .length,
+        equals(1),
+      );
+      final flashButton = find.byType(AwesomeFlashButton);
+      await $.tester.tap(flashButton, warnIfMissed: false);
+      await $.pump(const Duration(milliseconds: 400));
+      // FLash auto next
+      expect(
+        find
+            .byType(Icon)
+            .evaluate()
+            .where(
+              (element) => (element.widget as Icon).icon == Icons.flash_auto,
+            )
+            .length,
+        equals(1),
+      );
+      await $.tester.tap(flashButton, warnIfMissed: false);
+      await $.pump(const Duration(milliseconds: 100));
+      // FLash on next
+      expect(
+        find
+            .byType(Icon)
+            .evaluate()
+            .where((element) => (element.widget as Icon).icon == Icons.flash_on)
+            .length,
+        equals(1),
+      );
+      await $.tester.tap(flashButton, warnIfMissed: false);
+      await $.pump(const Duration(milliseconds: 100));
+      // FLash always next
+      expect(
+        find
+            .byType(Icon)
+            .evaluate()
+            .where(
+              (element) => (element.widget as Icon).icon == Icons.flashlight_on,
+            )
+            .length,
+        equals(1),
+      );
+      await $.tester.tap(flashButton, warnIfMissed: false);
+      await $.pump(const Duration(milliseconds: 100));
+      // Back to flash none
+      expect(
+        find
+            .byType(Icon)
+            .evaluate()
+            .where(
+              (element) => (element.widget as Icon).icon == Icons.flash_off,
+            )
+            .length,
+        equals(1),
+      );
+    },
+  );
 
   // This group of test only works when location is enabled on the phone
   // TODO Try to use Patrol to enable location manually on the device
 
-  patrolTest('Location > Do NOT save if not specified',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.photo(
-          pathBuilder: () => tempPath('single_photo_back_no_gps.jpg'),
+  patrol(
+    'Location > Do NOT save if not specified',
+    ($) async {
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.photo(
+            pathBuilder: () => tempPath('single_photo_back_no_gps.jpg'),
+          ),
         ),
-      ),
-    );
+      );
 
-    await allowPermissionsIfNeeded($);
+      await allowPermissionsIfNeeded($);
 
-    // await $.native.openQuickSettings();
-    // await $.native.tap(Selector(text: 'Location'));
-    // await $.native.pressBack();
+      // await $.native.openQuickSettings();
+      // await $.native.tap(Selector(text: 'Location'));
+      // await $.native.pressBack();
 
-    await $(AwesomeCaptureButton).tap();
-    final filePath = await tempPath('single_photo_back_no_gps.jpg');
-    final exif = await readExifFromFile(File(filePath));
-    final gpsTags = exif.entries.where(
-      (element) => element.key.contains('GPSDate'),
-    );
-    // TODO for some reason, 8 gps fields are set on android emulators even when no gps data are provided. When GPS is on, there are 11 fields instead.
-    expect(gpsTags.length, lessThan(11));
-  });
+      await $(AwesomeCaptureButton).tap();
+      final filePath = await tempPath('single_photo_back_no_gps.jpg');
+      final exif = await readExifFromFile(File(filePath));
+      final gpsTags = exif.entries.where(
+        (element) => element.key.contains('GPSDate'),
+      );
+      // TODO for some reason, 8 gps fields are set on android emulators even when no gps data are provided. When GPS is on, there are 11 fields instead.
+      expect(gpsTags.length, lessThan(11));
+    },
+  );
 
-  patrolTest('Location > Save if specified',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.photo(
-          pathBuilder: () => tempPath('single_photo_back_gps.jpg'),
+  patrol(
+    'Location > Save if specified',
+    ($) async {
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.photo(
+            pathBuilder: () => tempPath('single_photo_back_gps.jpg'),
+          ),
+          exifPreferences: ExifPreferences(saveGPSLocation: true),
         ),
-        exifPreferences: ExifPreferences(saveGPSLocation: true),
-      ),
-    );
+      );
 
-    await allowPermissionsIfNeeded($);
+      await allowPermissionsIfNeeded($);
 
-    await $(AwesomeCaptureButton).tap();
-    final filePath = await tempPath('single_photo_back_gps.jpg');
-    final exif = await readExifFromFile(File(filePath));
-    final gpsTags = exif.entries.where(
-      (element) => element.key.startsWith('GPS GPS'),
-    );
-    expect(gpsTags.length, greaterThan(0));
-  });
+      await $(AwesomeCaptureButton).tap();
+      final filePath = await tempPath('single_photo_back_gps.jpg');
+      final exif = await readExifFromFile(File(filePath));
+      final gpsTags = exif.entries.where(
+        (element) => element.key.startsWith('GPS GPS'),
+      );
+      expect(gpsTags.length, greaterThan(0));
+    },
+  );
 
-  patrolTest(
-      'Focus > On camera preview tap, show focus indicator for 2 seconds',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.photo(
-          pathBuilder: () => tempPath('single_photo_back.jpg'),
+  patrol(
+    'Focus > On camera preview tap, show focus indicator for 2 seconds',
+    ($) async {
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.photo(
+            pathBuilder: () => tempPath('single_photo_back.jpg'),
+          ),
         ),
-      ),
-    );
+      );
 
-    await allowPermissionsIfNeeded($);
+      await allowPermissionsIfNeeded($);
 
-    expect($(AwesomeFocusIndicator), findsNothing);
-    await $(AwesomeCameraGestureDetector).tap(andSettle: false);
-    expect($(AwesomeFocusIndicator), findsOneWidget);
-    // [OnPreviewTap.tapPainterDuration] should last 2 seconds by default
-    await $.pump(const Duration(seconds: 2));
-    expect($(AwesomeFocusIndicator), findsNothing);
-  });
+      expect($(AwesomeFocusIndicator), findsNothing);
+      await $(AwesomeCameraGestureDetector).tap(andSettle: false);
+      expect($(AwesomeFocusIndicator), findsOneWidget);
+      // [OnPreviewTap.tapPainterDuration] should last 2 seconds by default
+      await $.pump(const Duration(seconds: 2));
+      expect($(AwesomeFocusIndicator), findsNothing);
+    },
+  );
 
-  patrolTest('Focus > On multiple focus, last more than 2 seconds',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.photo(
-          pathBuilder: () => tempPath('single_photo_back.jpg'),
+  patrol(
+    'Focus > On multiple focus, last more than 2 seconds',
+    ($) async {
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.photo(
+            pathBuilder: () => tempPath('single_photo_back.jpg'),
+          ),
         ),
-      ),
-    );
+      );
 
-    await allowPermissionsIfNeeded($);
+      await allowPermissionsIfNeeded($);
 
-    expect($(AwesomeFocusIndicator), findsNothing);
-    await $(AwesomeCameraGestureDetector).tap(andSettle: false);
-    expect($(AwesomeFocusIndicator), findsOneWidget);
-    await $.pump(const Duration(seconds: 1));
-    // Focus again after one sec, meaning the focus indicator should last 3 seconds total
-    await $(AwesomeCameraGestureDetector).tap(andSettle: false);
-    await $.pump(const Duration(seconds: 1));
-    expect($(AwesomeFocusIndicator), findsOneWidget);
-    await $.pump(const Duration(seconds: 1));
-    expect($(AwesomeFocusIndicator), findsNothing);
-  });
+      expect($(AwesomeFocusIndicator), findsNothing);
+      await $(AwesomeCameraGestureDetector).tap(andSettle: false);
+      expect($(AwesomeFocusIndicator), findsOneWidget);
+      await $.pump(const Duration(seconds: 1));
+      // Focus again after one sec, meaning the focus indicator should last 3 seconds total
+      await $(AwesomeCameraGestureDetector).tap(andSettle: false);
+      await $.pump(const Duration(seconds: 1));
+      expect($(AwesomeFocusIndicator), findsOneWidget);
+      await $.pump(const Duration(seconds: 1));
+      expect($(AwesomeFocusIndicator), findsNothing);
+    },
+  );
 }

--- a/example/integration_test/video_test.dart
+++ b/example/integration_test/video_test.dart
@@ -4,156 +4,154 @@ import 'dart:io';
 import 'package:camera_app/drivable_camera.dart';
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:patrol/patrol.dart';
 
-import 'config.dart';
-import 'utils.dart';
+import 'common.dart';
 
 // To run it, you have to use `patrol drive` instead of `flutter test`.
 void main() {
   for (final sensor in Sensors.values) {
-    patrolTest('Record video >  one with ${Sensors.back}',
-        config: patrolConfig,
-        nativeAutomatorConfig: nativeAutomatorConfig,
-        nativeAutomation: true, ($) async {
-      await $.pumpWidgetAndSettle(
-        DrivableCamera(
-          sensor: sensor,
-          saveConfig: SaveConfig.video(
-            pathBuilder: () =>
-                tempPath('record_video_single_${sensor.name}.mp4'),
+    patrol(
+      'Record video >  one with ${Sensors.back}',
+      ($) async {
+        await $.pumpWidgetAndSettle(
+          DrivableCamera(
+            sensor: sensor,
+            saveConfig: SaveConfig.video(
+              pathBuilder: () =>
+                  tempPath('record_video_single_${sensor.name}.mp4'),
+            ),
           ),
-        ),
-      );
-      await allowPermissionsIfNeeded($);
+        );
+        await allowPermissionsIfNeeded($);
 
-      final filePath = await tempPath('record_video_single_${sensor.name}.mp4');
-      await $(AwesomeCaptureButton).tap(andSettle: false);
-      await allowPermissionsIfNeeded($);
-      await $.pump(const Duration(seconds: 3));
-      await $(AwesomeCaptureButton).tap();
-      await $.pump(const Duration(milliseconds: 2000));
-
-      expect(File(filePath).existsSync(), true);
-      // File size should be quite high (at least more than 100)
-      expect(File(filePath).lengthSync(), greaterThan(100));
-    });
-
-    patrolTest('Record video > multiple ${Sensors.back} camera',
-        config: patrolConfig,
-        nativeAutomatorConfig: nativeAutomatorConfig,
-        nativeAutomation: true, ($) async {
-      int idxVideo = 0;
-      const videosToTake = 3;
-      await $.pumpWidgetAndSettle(
-        DrivableCamera(
-          sensor: sensor,
-          saveConfig: SaveConfig.video(
-            pathBuilder: () =>
-                tempPath('multiple_video_${sensor.name}_$idxVideo.mp4'),
-          ),
-        ),
-      );
-      await allowPermissionsIfNeeded($);
-
-      for (int i = 0; i < videosToTake; i++) {
         final filePath =
-            await tempPath('multiple_video_${sensor.name}_$idxVideo.mp4');
+            await tempPath('record_video_single_${sensor.name}.mp4');
+        await $(AwesomeCaptureButton).tap(andSettle: false);
+        await allowPermissionsIfNeeded($);
+        await $.pump(const Duration(seconds: 3));
+        await $(AwesomeCaptureButton).tap();
+        await $.pump(const Duration(milliseconds: 2000));
+
+        expect(File(filePath).existsSync(), true);
+        // File size should be quite high (at least more than 100)
+        expect(File(filePath).lengthSync(), greaterThan(100));
+      },
+    );
+
+    patrol(
+      'Record video > multiple ${Sensors.back} camera',
+      ($) async {
+        int idxVideo = 0;
+        const videosToTake = 3;
+        await $.pumpWidgetAndSettle(
+          DrivableCamera(
+            sensor: sensor,
+            saveConfig: SaveConfig.video(
+              pathBuilder: () =>
+                  tempPath('multiple_video_${sensor.name}_$idxVideo.mp4'),
+            ),
+          ),
+        );
+        await allowPermissionsIfNeeded($);
+
+        for (int i = 0; i < videosToTake; i++) {
+          final filePath =
+              await tempPath('multiple_video_${sensor.name}_$idxVideo.mp4');
+          await $(AwesomeCaptureButton).tap(andSettle: false);
+          await allowPermissionsIfNeeded($);
+          await Future.delayed(const Duration(seconds: 3));
+          await $(AwesomeCaptureButton).tap();
+          await $.pump(const Duration(milliseconds: 1000));
+          expect(File(filePath).existsSync(), true);
+          // File size should be quite high (at least more than 100)
+          expect(File(filePath).lengthSync(), greaterThan(100));
+        }
+      },
+    );
+
+    patrol(
+      'Record video > Pause and resume',
+      ($) async {
+        await $.pumpWidgetAndSettle(
+          DrivableCamera(
+            sensor: sensor,
+            saveConfig: SaveConfig.video(
+                pathBuilder: () => tempPath('pause_resume_video_$sensor.mp4')),
+          ),
+        );
+
+        await allowPermissionsIfNeeded($);
+
+        final filePath = await tempPath('pause_resume_video_$sensor.mp4');
+
+        await $(AwesomeCaptureButton).tap(andSettle: false);
+        await allowPermissionsIfNeeded($);
+        await Future.delayed(const Duration(seconds: 2));
+        await $.tester.pumpAndSettle();
+        final pauseResumeButton = find.byType(AwesomePauseResumeButton);
+        await $.tester.tap(pauseResumeButton, warnIfMissed: false);
+        await Future.delayed(const Duration(seconds: 3));
+        await $.tester.tap(pauseResumeButton, warnIfMissed: false);
+        await Future.delayed(const Duration(seconds: 1));
+
+        await $(AwesomeCaptureButton).tap();
+        await $.pump(const Duration(milliseconds: 1000));
+
+        final file = File(filePath);
+        expect(file.existsSync(), true);
+        // File size should be quite high (at least more than 100)
+        expect(file.lengthSync(), greaterThan(100));
+        // We might test that the video lasts 3 seconds (2+1) and not 6 (2+3+1)
+        // Didn't work using video_player (error in native side) neither using
+        // video_compress (metadata null)
+      },
+    );
+  }
+
+  patrol(
+    'Record video > One with ${Sensors.back} then one with ${Sensors.front}',
+    ($) async {
+      int idxSensor = 0;
+      final sensors = [
+        Sensors.back,
+        Sensors.front,
+        Sensors.back,
+      ];
+      await $.pumpWidgetAndSettle(
+        DrivableCamera(
+          sensor: Sensors.back,
+          saveConfig: SaveConfig.video(
+            pathBuilder: () async {
+              final path = await tempPath(
+                  'switch_sensor_video_${idxSensor}_${sensors[idxSensor].name}.mp4');
+              idxSensor++;
+              return path;
+            },
+          ),
+        ),
+      );
+
+      await allowPermissionsIfNeeded($);
+
+      for (int i = 0; i < sensors.length; i++) {
+        final filePath = await tempPath(
+            'switch_sensor_video_${idxSensor}_${sensors[idxSensor].name}.mp4');
+
+        if (i > 0 && sensors[i - 1] != sensors[i]) {
+          await $.tester.pumpAndSettle();
+          final switchButton = find.byType(AwesomeCameraSwitchButton);
+          await $.tester.tap(switchButton, warnIfMissed: false);
+        }
         await $(AwesomeCaptureButton).tap(andSettle: false);
         await allowPermissionsIfNeeded($);
         await Future.delayed(const Duration(seconds: 3));
         await $(AwesomeCaptureButton).tap();
-        await $.pump(const Duration(milliseconds: 1000));
+        await $.pump(const Duration(milliseconds: 2000));
+
         expect(File(filePath).existsSync(), true);
         // File size should be quite high (at least more than 100)
         expect(File(filePath).lengthSync(), greaterThan(100));
       }
-    });
-
-    patrolTest('Record video > Pause and resume',
-        config: patrolConfig,
-        nativeAutomatorConfig: nativeAutomatorConfig,
-        nativeAutomation: true, ($) async {
-      await $.pumpWidgetAndSettle(
-        DrivableCamera(
-          sensor: sensor,
-          saveConfig: SaveConfig.video(
-              pathBuilder: () => tempPath('pause_resume_video_$sensor.mp4')),
-        ),
-      );
-
-      await allowPermissionsIfNeeded($);
-
-      final filePath = await tempPath('pause_resume_video_$sensor.mp4');
-
-      await $(AwesomeCaptureButton).tap(andSettle: false);
-      await allowPermissionsIfNeeded($);
-      await Future.delayed(const Duration(seconds: 2));
-      await $.tester.pumpAndSettle();
-      final pauseResumeButton = find.byType(AwesomePauseResumeButton);
-      await $.tester.tap(pauseResumeButton, warnIfMissed: false);
-      await Future.delayed(const Duration(seconds: 3));
-      await $.tester.tap(pauseResumeButton, warnIfMissed: false);
-      await Future.delayed(const Duration(seconds: 1));
-
-      await $(AwesomeCaptureButton).tap();
-      await $.pump(const Duration(milliseconds: 1000));
-
-      final file = File(filePath);
-      expect(file.existsSync(), true);
-      // File size should be quite high (at least more than 100)
-      expect(file.lengthSync(), greaterThan(100));
-      // We might test that the video lasts 3 seconds (2+1) and not 6 (2+3+1)
-      // Didn't work using video_player (error in native side) neither using
-      // video_compress (metadata null)
-    });
-  }
-
-  patrolTest(
-      'Record video > One with ${Sensors.back} then one with ${Sensors.front}',
-      config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig,
-      nativeAutomation: true, ($) async {
-    int idxSensor = 0;
-    final sensors = [
-      Sensors.back,
-      Sensors.front,
-      Sensors.back,
-    ];
-    await $.pumpWidgetAndSettle(
-      DrivableCamera(
-        sensor: Sensors.back,
-        saveConfig: SaveConfig.video(
-          pathBuilder: () async {
-            final path = await tempPath(
-                'switch_sensor_video_${idxSensor}_${sensors[idxSensor].name}.mp4');
-            idxSensor++;
-            return path;
-          },
-        ),
-      ),
-    );
-
-    await allowPermissionsIfNeeded($);
-
-    for (int i = 0; i < sensors.length; i++) {
-      final filePath = await tempPath(
-          'switch_sensor_video_${idxSensor}_${sensors[idxSensor].name}.mp4');
-
-      if (i > 0 && sensors[i - 1] != sensors[i]) {
-        await $.tester.pumpAndSettle();
-        final switchButton = find.byType(AwesomeCameraSwitchButton);
-        await $.tester.tap(switchButton, warnIfMissed: false);
-      }
-      await $(AwesomeCaptureButton).tap(andSettle: false);
-      await allowPermissionsIfNeeded($);
-      await Future.delayed(const Duration(seconds: 3));
-      await $(AwesomeCaptureButton).tap();
-      await $.pump(const Duration(milliseconds: 2000));
-
-      expect(File(filePath).existsSync(), true);
-      // File size should be quite high (at least more than 100)
-      expect(File(filePath).lengthSync(), greaterThan(100));
-    }
-  });
+    },
+  );
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -274,7 +274,7 @@ packages:
     source: hosted
     version: "4.0.13"
   integration_test:
-    dependency: "direct dev"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -402,10 +402,10 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: "7e46c7a2e3f9012ed6e8651247cb7980d48ae0d8aac6269422f3872d33c46608"
+      sha256: f81b997b845eb73c7d6843ec8ec2b36ef4e8d14f4e32eaa6557715a4907beedd
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.8"
+    version: "1.0.3"
   petitparser:
     dependency: transitive
     description:
@@ -630,4 +630,4 @@ packages:
     version: "6.2.2"
 sdks:
   dart: ">=2.19.0 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,9 +23,7 @@ dev_dependencies:
   exif: ^3.1.2
   flutter_test:
     sdk: flutter
-  integration_test:
-    sdk: flutter
-  patrol: ^0.10.8
+  patrol: ^1.0.3
   flutter_lints: ^2.0.1
 
 flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,8 +22,7 @@ dependencies:
 dev_dependencies:
   exif: ^3.1.2
   flutter_test:
-    sdk:
-      flutter
+    sdk: flutter
   integration_test:
     sdk: flutter
   patrol: ^0.10.8
@@ -34,3 +33,9 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+
+patrol:
+  android:
+    package_name: com.example.camera_app
+  ios:
+    bundle_id:

--- a/example/test_driver/integration_test.dart
+++ b/example/test_driver/integration_test.dart
@@ -1,3 +1,0 @@
-import 'package:integration_test/integration_test_driver.dart';
-
-Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Description

I migrated integration tests to use Patrol 1.0.

In more detail:
- created a `patrol()` helper-wrapper function around `patrolTest()`
- integrated Android as per [the docs](https://patrol.leancode.co/native/setup#integrate-with-native-side)

WIP. Current status:

![Screenshot 2023-02-20 at 12 48 10 AM](https://user-images.githubusercontent.com/40357511/219982851-4a4dad08-3009-4111-9188-05dd162e82b6.png)

## Checklist

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.