### PR TITLE
🐛 Fix patrol tests

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -383,6 +383,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
                             val exif = ExifInterface(outputFileResults.savedUri!!.path!!)
                             outputFileOptions.metadata.location = it
                             exif.setGpsInfo(it)
+//                            Log.d("CAMERAX__EXIF", "GPS info saved ${it?.latitude} ${it?.longitude}")
                             // We need to actually save the exif data to the file system
                             exif.saveAttributes()
                             callback(Result.success(true))

--- a/example/integration_test/common.dart
+++ b/example/integration_test/common.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:patrol/patrol.dart';
 
+@isTest
 void patrol(
   String description,
   Future<void> Function(PatrolTester) callback, {

--- a/example/integration_test/ui_test.dart
+++ b/example/integration_test/ui_test.dart
@@ -27,7 +27,7 @@ void main() {
 
       await allowPermissionsIfNeeded($);
 
-      expect($(#ratioButton), findsOneWidget);
+      expect($(AwesomeAspectRatioButton), findsOneWidget);
       expect($(AwesomeFlashButton), findsOneWidget);
       expect(
         $(AwesomeLocationButton).$(AwesomeBouncingWidget),
@@ -46,7 +46,7 @@ void main() {
 
       // Switch to video mode
       await $.tap(find.text("VIDEO"));
-      expect($(#ratioButton), findsNothing);
+      expect($(AwesomeAspectRatioButton), findsNothing);
       expect($(AwesomeFlashButton), findsOneWidget);
       expect(
         $(AwesomeLocationButton).$(AwesomeBouncingWidget),
@@ -76,7 +76,7 @@ void main() {
 
       await allowPermissionsIfNeeded($);
 
-      expect($(#ratioButton), findsOneWidget);
+      expect($(AwesomeAspectRatioButton), findsOneWidget);
       expect($(AwesomeFlashButton), findsOneWidget);
       expect(
         $(AwesomeLocationButton).$(AwesomeBouncingWidget),
@@ -106,11 +106,10 @@ void main() {
       );
 
       await allowPermissionsIfNeeded($);
-
-      await $.pump(const Duration(milliseconds: 2000));
+      await $.pump(const Duration(milliseconds: 1000));
 
       // Ratio button is not visible in video mode
-      expect($(#ratioButton), findsNothing);
+      expect($(AwesomeAspectRatioButton), findsNothing);
       expect($(AwesomeFlashButton), findsOneWidget);
       expect($(AwesomeLocationButton).$(AwesomeBouncingWidget), findsNothing);
       expect($(AwesomeCameraSwitchButton), findsOneWidget);
@@ -121,11 +120,12 @@ void main() {
       expect($(AwesomeCaptureButton), findsOneWidget);
       expect($(AwesomeCameraModeSelector).$(PageView), findsOneWidget);
 
-      await $(AwesomeCaptureButton).tap();
+      await $(AwesomeCaptureButton).tap(andSettle: false);
       await allowPermissionsIfNeeded($);
+      await $.pump(const Duration(milliseconds: 2000));
 
-      // Recording
-      expect($(#ratioButton), findsNothing);
+      // // Recording
+      expect($(AwesomeAspectRatioButton), findsNothing);
       expect($(AwesomeFlashButton), findsNothing);
       expect($(AwesomeLocationButton).$(AwesomeBouncingWidget), findsNothing);
       expect($(AwesomeCameraSwitchButton), findsNothing);
@@ -135,11 +135,11 @@ void main() {
       expect($(AwesomeCaptureButton), findsOneWidget);
       expect($(AwesomeCameraModeSelector).$(PageView), findsNothing);
 
-      await $(AwesomeCaptureButton).tap();
-      await $.pump(const Duration(milliseconds: 2000));
+      await $(AwesomeCaptureButton).tap(andSettle: false);
+      await $.pump(const Duration(milliseconds: 4000));
 
       // Not recording
-      expect($(#ratioButton), findsNothing);
+      expect($(AwesomeAspectRatioButton), findsNothing);
       expect($(AwesomeFlashButton), findsOneWidget);
       expect($(AwesomeLocationButton).$(AwesomeBouncingWidget), findsNothing);
       expect($(AwesomeCameraSwitchButton), findsOneWidget);
@@ -267,6 +267,8 @@ void main() {
     },
   );
 
+  // TODO Doesn't work on Firebase Test Lab, Exif GPS data is not saved (but works on local emulator)
+  // See EXIF_PRINT logs at https://console.firebase.google.com/u/0/project/camerawesome-6e777/testlab/histories/bh.a7d83610595ed8b2/matrices/4861867399844663011/executions/bs.9deb07f6afc5c21c/logs
   patrol(
     'Location > Save if specified',
     ($) async {
@@ -282,9 +284,13 @@ void main() {
 
       await allowPermissionsIfNeeded($);
 
-      await $(AwesomeCaptureButton).tap();
+      await $(AwesomeCaptureButton).tap(andSettle: false);
+      await $.pump(const Duration(seconds: 2));
       final filePath = await tempPath('single_photo_back_gps.jpg');
       final exif = await readExifFromFile(File(filePath));
+      // for(final entry in exif.entries) {
+      //   print('EXIF_PRINT > ${entry.key} : ${entry.value}');
+      // }
       final gpsTags = exif.entries.where(
         (element) => element.key.startsWith('GPS GPS'),
       );

--- a/example/integration_test/ui_test.dart
+++ b/example/integration_test/ui_test.dart
@@ -267,8 +267,8 @@ void main() {
     },
   );
 
-  // TODO Doesn't work on Firebase Test Lab, Exif GPS data is not saved (but works on local emulator)
-  // See EXIF_PRINT logs at https://console.firebase.google.com/u/0/project/camerawesome-6e777/testlab/histories/bh.a7d83610595ed8b2/matrices/4861867399844663011/executions/bs.9deb07f6afc5c21c/logs
+  // This test might not pass in Firebase Test Lab because location does not seem to be activated. It works on local device.
+  // TODO Try to use Patrol to enable location manually on the device
   patrol(
     'Location > Save if specified',
     ($) async {
@@ -285,10 +285,11 @@ void main() {
       await allowPermissionsIfNeeded($);
 
       await $(AwesomeCaptureButton).tap(andSettle: false);
-      await $.pump(const Duration(seconds: 2));
+      // TODO Wait for media captured instead of a fixed duration (taking picture + retrieving locaiton might take a lot of time)
+      await $.pump(const Duration(seconds: 4));
       final filePath = await tempPath('single_photo_back_gps.jpg');
       final exif = await readExifFromFile(File(filePath));
-      // for(final entry in exif.entries) {
+      // for (final entry in exif.entries) {
       //   print('EXIF_PRINT > ${entry.key} : ${entry.value}');
       // }
       final gpsTags = exif.entries.where(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
     source: hosted
     version: "0.17.2"
   exif:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: exif
       sha256: "542fd8dd8eda3dff65be415f38370541aecf9eb3663e0679d9da4689f6b16c8f"
@@ -394,10 +394,10 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: f81b997b845eb73c7d6843ec8ec2b36ef4e8d14f4e32eaa6557715a4907beedd
+      sha256: "0c4f23ddf1e8754c76fbcbf364a6c10f93ac2568d95d48ee9a04f0e35a6b1e6f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.8"
   petitparser:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -327,7 +327,7 @@ packages:
     source: hosted
     version: "1.0.4"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=2.18.2 <3.0.0'
+  flutter: '>=3.3.0'
 
 dependencies:
   flutter:
@@ -17,6 +18,7 @@ dependencies:
   google_mlkit_barcode_scanning: ^0.5.0
   google_mlkit_text_recognition: ^0.5.0
   image: ^4.0.15
+  meta: ^1.8.0
   rxdart: ^0.27.7
   video_player: ^2.5.0
 
@@ -24,7 +26,7 @@ dev_dependencies:
   exif: ^3.1.2
   flutter_test:
     sdk: flutter
-  patrol: ^1.0.3
+  patrol: ^1.0.8
   flutter_lints: ^2.0.1
 
 flutter:


### PR DESCRIPTION
## Description

Fixes tests not passing.

- [x] local emulator (Pixel 6 running Android 13)
- [ ] Firebase Test Lab (Pixel 7 Pro)
  - Saving GPS to Exif metadata doesn't seem to work, other tests are OK
    - Firebase might not enable GPS location by default, which would cause this behaviour
- [x] Physical device (Xiaomi Mi 9T, Android 11, MIUI 12.1.4)
  - Patrol doesn't launch the tests, but if launched manually, the tests are run


This follows #296 thanks to the help from @bartekpacia 💪
Fixes #267 

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*