### PR TITLE
💥 Sensors API breaking changes

### DIFF
--- a/example/lib/ai_analysis_faces.dart
+++ b/example/lib/ai_analysis_faces.dart
@@ -66,8 +66,10 @@ class _CameraPageState extends State<CameraPage> {
     return Scaffold(
       body: CameraAwesomeBuilder.previewOnly(
         previewFit: CameraPreviewFit.contain,
-        aspectRatio: CameraAspectRatios.ratio_1_1,
-        sensors: [Sensor.position(SensorPosition.front)],
+        sensorConfig: SensorConfig.single(
+          sensor: Sensor.position(SensorPosition.front),
+          aspectRatio: CameraAspectRatios.ratio_1_1,
+        ),
         onImageForAnalysis: (img) => _analyzeImage(img),
         imageAnalysisConfig: AnalysisConfig(
           androidOptions: const AndroidAnalysisOptions.nv21(

--- a/example/lib/analysis_image_filter.dart
+++ b/example/lib/analysis_image_filter.dart
@@ -43,8 +43,10 @@ class _CameraPageState extends State<CameraPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: CameraAwesomeBuilder.analysisOnly(
-        aspectRatio: CameraAspectRatios.ratio_1_1,
-        sensors: [Sensor.position(SensorPosition.front)],
+        sensorConfig: SensorConfig.single(
+          sensor: Sensor.position(SensorPosition.front),
+          aspectRatio: CameraAspectRatios.ratio_1_1,
+        ),
         onImageForAnalysis: (img) async => _imageStreamController.add(img),
         imageAnalysisConfig: AnalysisConfig(
           androidOptions: const AndroidAnalysisOptions.yuv420(

--- a/example/lib/analysis_image_filter_picker.dart
+++ b/example/lib/analysis_image_filter_picker.dart
@@ -43,8 +43,10 @@ class _CameraPageState extends State<CameraPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: CameraAwesomeBuilder.analysisOnly(
-        aspectRatio: CameraAspectRatios.ratio_1_1,
-        sensors: [Sensor.position(SensorPosition.front)],
+        sensorConfig: SensorConfig.single(
+          sensor: Sensor.position(SensorPosition.front),
+          aspectRatio: CameraAspectRatios.ratio_1_1,
+        ),
         onImageForAnalysis: (img) async => _imageStreamController.add(img),
         imageAnalysisConfig: AnalysisConfig(
           androidOptions: const AndroidAnalysisOptions.yuv420(

--- a/example/lib/camera_analysis_capabilities.dart
+++ b/example/lib/camera_analysis_capabilities.dart
@@ -44,7 +44,9 @@ class CameraPage extends StatelessWidget {
             ),
             maxFramesPerSecond: 3,
           ),
-          sensors: [sensor],
+          sensorConfig: SensorConfig.single(
+            sensor: sensor,
+          ),
           previewDecoratorBuilder: (state, _, __) {
             return Center(
               child: FutureBuilder<bool>(

--- a/example/lib/custom_awesome_ui.dart
+++ b/example/lib/custom_awesome_ui.dart
@@ -28,7 +28,10 @@ class CameraPage extends StatelessWidget {
         saveConfig: SaveConfig.photo(
           pathBuilder: () => path(CaptureMode.photo),
         ),
-        aspectRatio: CameraAspectRatios.ratio_1_1,
+        sensorConfig: SensorConfig.single(
+          sensor: Sensor.position(SensorPosition.back),
+          aspectRatio: CameraAspectRatios.ratio_1_1,
+        ),
         previewFit: CameraPreviewFit.contain,
         previewPadding: const EdgeInsets.only(left: 150, top: 100),
         previewAlignment: Alignment.topRight,

--- a/example/lib/custom_theme.dart
+++ b/example/lib/custom_theme.dart
@@ -32,7 +32,9 @@ class CameraPage extends StatelessWidget {
           initialCaptureMode: CaptureMode.photo,
         ),
         filter: AwesomeFilter.AddictiveRed,
-        aspectRatio: CameraAspectRatios.ratio_1_1,
+        sensorConfig: SensorConfig.single(
+          aspectRatio: CameraAspectRatios.ratio_1_1,
+        ),
         previewFit: CameraPreviewFit.fitWidth,
         // Buttons of CamerAwesome UI will use this theme
         theme: AwesomeTheme(

--- a/example/lib/drivable_camera.dart
+++ b/example/lib/drivable_camera.dart
@@ -21,9 +21,16 @@ class DrivableCamera extends StatelessWidget {
         body: CameraAwesomeBuilder.awesome(
           saveConfig: saveConfig,
           onMediaTap: (media) {},
-          sensors: sensors,
+          sensorConfig: sensors.length == 1
+              ? SensorConfig.single(
+                  aspectRatio: CameraAspectRatios.ratio_1_1,
+                  flashMode: FlashMode.always,
+                )
+              : SensorConfig.multiple(
+                  sensors: sensors,
+                  flashMode: FlashMode.always,
+                ),
           exifPreferences: exifPreferences,
-          flashMode: FlashMode.always,
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,13 +33,12 @@ class CameraPage extends StatelessWidget {
             videoPathBuilder: () => path(CaptureMode.video),
             initialCaptureMode: CaptureMode.photo,
           ),
-          sensors: [
-            Sensor.position(SensorPosition.back),
-          ],
+          sensorConfig: SensorConfig.single(
+            flashMode: FlashMode.auto,
+            aspectRatio: CameraAspectRatios.ratio_16_9,
+          ),
           enablePhysicalButton: true,
           // filter: AwesomeFilter.AddictiveRed,
-          flashMode: FlashMode.auto,
-          aspectRatio: CameraAspectRatios.ratio_16_9,
           previewFit: CameraPreviewFit.fitWidth,
           onMediaTap: (mediaCapture) {
             OpenFile.open(mediaCapture.filePath);

--- a/example/lib/multi_camera.dart
+++ b/example/lib/multi_camera.dart
@@ -52,17 +52,19 @@ class _CameraPageState extends State<CameraPage> {
                   videoPathBuilder: () => path(CaptureMode.video),
                   initialCaptureMode: CaptureMode.photo,
                 ),
-                sensors: [
-                  Sensor.position(SensorPosition.back),
-                  Sensor.position(SensorPosition.front),
-                  Sensor.type(SensorType.telephoto),
-                ],
+                sensorConfig: SensorConfig.multiple(
+                  sensors: [
+                    Sensor.position(SensorPosition.back),
+                    Sensor.position(SensorPosition.front),
+                    Sensor.type(SensorType.telephoto),
+                  ],
+                  flashMode: FlashMode.auto,
+                  aspectRatio: CameraAspectRatios.ratio_16_9,
+                ),
                 // TODO: create factory for multi cam & single
                 // sensors: sensorDeviceData!.availableSensors
                 //     .map((e) => Sensor.id(e.uid))
                 //     .toList(),
-                flashMode: FlashMode.auto,
-                aspectRatio: CameraAspectRatios.ratio_16_9,
                 previewFit: CameraPreviewFit.fitWidth,
                 onMediaTap: (mediaCapture) {
                   // TODO: multiple files

--- a/example/lib/preview_overlay_example.dart
+++ b/example/lib/preview_overlay_example.dart
@@ -47,8 +47,10 @@ class _CameraPageState extends State<CameraPage> {
             videoPathBuilder: () => path(CaptureMode.video),
             initialCaptureMode: CaptureMode.photo,
           ),
-          flashMode: FlashMode.auto,
-          aspectRatio: CameraAspectRatios.ratio_16_9,
+          sensorConfig: SensorConfig.single(
+            flashMode: FlashMode.auto,
+            aspectRatio: CameraAspectRatios.ratio_16_9,
+          ),
           previewFit: CameraPreviewFit.fitWidth,
           onMediaTap: (mediaCapture) {
             OpenFile.open(mediaCapture.filePath);

--- a/example/lib/subroute_camera.dart
+++ b/example/lib/subroute_camera.dart
@@ -49,8 +49,10 @@ class CameraPage extends StatelessWidget {
                 initialCaptureMode: CaptureMode.photo,
               ),
               filter: AwesomeFilter.AddictiveRed,
-              flashMode: FlashMode.auto,
-              aspectRatio: CameraAspectRatios.ratio_16_9,
+              sensorConfig: SensorConfig.single(
+                flashMode: FlashMode.auto,
+                aspectRatio: CameraAspectRatios.ratio_16_9,
+              ),
               previewFit: CameraPreviewFit.fitWidth,
               onMediaTap: (mediaCapture) {
                 OpenFile.open(mediaCapture.filePath);

--- a/lib/src/orchestrator/models/camera_config.dart
+++ b/lib/src/orchestrator/models/camera_config.dart
@@ -1,0 +1,9 @@
+import 'sensors.dart';
+
+class CameraConfig {
+  final List<Sensor> sensors;
+
+  CameraConfig.single(Sensor sensor) : sensors = [sensor];
+
+  CameraConfig.multiple(this.sensors);
+}

--- a/lib/src/orchestrator/models/camera_config.dart
+++ b/lib/src/orchestrator/models/camera_config.dart
@@ -1,9 +1,0 @@
-import 'sensors.dart';
-
-class CameraConfig {
-  final List<Sensor> sensors;
-
-  CameraConfig.single(Sensor sensor) : sensors = [sensor];
-
-  CameraConfig.multiple(this.sensors);
-}

--- a/lib/src/orchestrator/models/sensor_config.dart
+++ b/lib/src/orchestrator/models/sensor_config.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:rxdart/rxdart.dart';
 
+// TODO find a way to explain that this sensorconfig is not bound anymore (user changed sensor for example)
 class SensorConfig {
   late BehaviorSubject<FlashMode> _flashModeController;
 
@@ -41,7 +42,35 @@ class SensorConfig {
       BehaviorSubject<double>();
   StreamSubscription? _brightnessSubscription;
 
-  SensorConfig({
+  SensorConfig.single({
+    Sensor? sensor,
+    FlashMode flashMode = FlashMode.none,
+    bool mirrorFrontCamera = false,
+    double zoom = 0.0,
+    CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
+  }) : this._(
+          sensors: [sensor ?? Sensor.position(SensorPosition.back)],
+          flash: flashMode,
+          mirrorFrontCamera: mirrorFrontCamera,
+          currentZoom: zoom,
+          aspectRatio: aspectRatio,
+        );
+
+  SensorConfig.multiple({
+    required List<Sensor> sensors,
+    FlashMode flashMode = FlashMode.none,
+    bool mirrorFrontCamera = false,
+    double zoom = 0.0,
+    CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
+  }) : this._(
+          sensors: sensors,
+          flash: flashMode,
+          mirrorFrontCamera: mirrorFrontCamera,
+          currentZoom: zoom,
+          aspectRatio: aspectRatio,
+        );
+
+  SensorConfig._({
     required this.sensors,
     FlashMode flash = FlashMode.none,
     bool mirrorFrontCamera = false,

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -44,18 +44,10 @@ typedef OnImageForAnalysis = Future Function(AnalysisImage image);
 /// - use our built in interface
 /// with the awesome factory
 class CameraAwesomeBuilder extends StatefulWidget {
-  /// [front] or [back] camera
-  final List<Sensor> sensors;
-
-  final FlashMode flashMode;
+  /// Which sensors you want to use
+  final SensorConfig sensorConfig;
 
   final bool mirrorFrontCamera;
-
-  /// Must be a value between 0.0 (no zoom) and 1.0 (max zoom)
-  final double zoom;
-
-  /// Ratio 1:1 is not supported yet on Android
-  final CameraAspectRatios aspectRatio;
 
   /// choose if you want to persist user location in image metadata or not
   final ExifPreferences? exifPreferences;
@@ -117,12 +109,9 @@ class CameraAwesomeBuilder extends StatefulWidget {
   final bool showPreview;
 
   const CameraAwesomeBuilder._({
-    required this.sensors,
-    required this.flashMode,
-    required this.zoom,
+    required this.sensorConfig,
     required this.mirrorFrontCamera,
     required this.enablePhysicalButton,
-    required this.aspectRatio,
     required this.exifPreferences,
     required this.enableAudio,
     required this.progressIndicator,
@@ -167,12 +156,9 @@ class CameraAwesomeBuilder extends StatefulWidget {
   /// [imageAnaysisConfig] and listen to the stream of images with
   /// [onImageForAnalysis].
   CameraAwesomeBuilder.awesome({
-    List<Sensor>? sensors,
-    FlashMode flashMode = FlashMode.none,
-    double zoom = 0.0,
+    SensorConfig? sensorConfig,
     bool mirrorFrontCamera = false,
     bool enablePhysicalButton = false,
-    CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
     ExifPreferences? exifPreferences,
     bool enableAudio = true,
     Widget? progressIndicator,
@@ -192,11 +178,12 @@ class CameraAwesomeBuilder extends StatefulWidget {
     EdgeInsets previewPadding = EdgeInsets.zero,
     Alignment previewAlignment = Alignment.center,
   }) : this._(
-          sensors: sensors ?? [Sensor.position(SensorPosition.back)],
-          flashMode: flashMode,
-          zoom: zoom,
+          sensorConfig: sensorConfig ??
+              SensorConfig.single(
+                sensor: Sensor.position(SensorPosition.back),
+                mirrorFrontCamera: mirrorFrontCamera,
+              ),
           mirrorFrontCamera: mirrorFrontCamera,
-          aspectRatio: aspectRatio,
           exifPreferences: exifPreferences,
           enableAudio: enableAudio,
           enablePhysicalButton: enablePhysicalButton,
@@ -228,12 +215,9 @@ class CameraAwesomeBuilder extends StatefulWidget {
   ///
   /// Documentation on its way, API might change
   CameraAwesomeBuilder.custom({
-    List<Sensor>? sensors,
-    FlashMode flashMode = FlashMode.none,
-    double zoom = 0.0,
+    SensorConfig? sensorConfig,
     bool mirrorFrontCamera = false,
     bool enablePhysicalButton = false,
-    CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
     ExifPreferences? exifPreferences,
     bool enableAudio = true,
     Widget? progressIndicator,
@@ -249,12 +233,13 @@ class CameraAwesomeBuilder extends StatefulWidget {
     EdgeInsets previewPadding = EdgeInsets.zero,
     Alignment previewAlignment = Alignment.center,
   }) : this._(
-          sensors: sensors ?? [Sensor.position(SensorPosition.back)],
-          flashMode: flashMode,
-          zoom: zoom,
+          sensorConfig: sensorConfig ??
+              SensorConfig.single(
+                sensor: Sensor.position(SensorPosition.back),
+                mirrorFrontCamera: mirrorFrontCamera,
+              ),
           mirrorFrontCamera: mirrorFrontCamera,
           enablePhysicalButton: enablePhysicalButton,
-          aspectRatio: aspectRatio,
           exifPreferences: exifPreferences,
           enableAudio: enableAudio,
           progressIndicator: progressIndicator,
@@ -276,10 +261,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
   /// Use this constructor when you don't want to take pictures or record videos.
   /// You can still do image analysis.
   CameraAwesomeBuilder.previewOnly({
-    List<Sensor>? sensors,
-    FlashMode flashMode = FlashMode.none,
-    double zoom = 0.0,
-    CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
+    SensorConfig? sensorConfig,
     Widget? progressIndicator,
     required CameraLayoutBuilder builder,
     AwesomeFilter? filter,
@@ -291,12 +273,10 @@ class CameraAwesomeBuilder extends StatefulWidget {
     EdgeInsets previewPadding = EdgeInsets.zero,
     Alignment previewAlignment = Alignment.center,
   }) : this._(
-    sensors: sensors ?? [Sensor.position(SensorPosition.back)],
-          flashMode: flashMode,
-          zoom: zoom,
+          sensorConfig: sensorConfig ??
+              SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
           mirrorFrontCamera: false,
           enablePhysicalButton: false,
-          aspectRatio: aspectRatio,
           exifPreferences: null,
           enableAudio: false,
           progressIndicator: progressIndicator,
@@ -323,7 +303,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
   /// You may still show the image from the analysis by converting it to JPEG
   /// and  displaying that JPEG image.
   CameraAwesomeBuilder.analysisOnly({
-    List<Sensor>? sensors,
+    SensorConfig? sensorConfig,
     FlashMode flashMode = FlashMode.none,
     double zoom = 0.0,
     CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
@@ -332,12 +312,10 @@ class CameraAwesomeBuilder extends StatefulWidget {
     required OnImageForAnalysis onImageForAnalysis,
     AnalysisConfig? imageAnalysisConfig,
   }) : this._(
-    sensors: sensors ?? [Sensor.position(SensorPosition.back)],
-          flashMode: flashMode,
-          zoom: zoom,
+          sensorConfig: sensorConfig ??
+              SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
           mirrorFrontCamera: false,
           enablePhysicalButton: false,
-          aspectRatio: aspectRatio,
           exifPreferences: null,
           enableAudio: false,
           progressIndicator: progressIndicator,
@@ -407,13 +385,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
     WidgetsBinding.instance.addObserver(this);
 
     _cameraContext = CameraContext.create(
-      SensorConfig(
-        sensors: widget.sensors,
-        flash: widget.flashMode,
-        currentZoom: widget.zoom,
-        mirrorFrontCamera: widget.mirrorFrontCamera,
-        aspectRatio: widget.aspectRatio,
-      ),
+      widget.sensorConfig,
       enablePhysicalButton: widget.enablePhysicalButton,
       filter: widget.filter ?? AwesomeFilter.None,
       initialCaptureMode: widget.saveConfig?.initialCaptureMode ??

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -47,8 +47,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
   /// Which sensors you want to use
   final SensorConfig sensorConfig;
 
-  final bool mirrorFrontCamera;
-
   /// choose if you want to persist user location in image metadata or not
   final ExifPreferences? exifPreferences;
 
@@ -110,7 +108,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
 
   const CameraAwesomeBuilder._({
     required this.sensorConfig,
-    required this.mirrorFrontCamera,
     required this.enablePhysicalButton,
     required this.exifPreferences,
     required this.enableAudio,
@@ -157,7 +154,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
   /// [onImageForAnalysis].
   CameraAwesomeBuilder.awesome({
     SensorConfig? sensorConfig,
-    bool mirrorFrontCamera = false,
     bool enablePhysicalButton = false,
     ExifPreferences? exifPreferences,
     bool enableAudio = true,
@@ -181,9 +177,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
           sensorConfig: sensorConfig ??
               SensorConfig.single(
                 sensor: Sensor.position(SensorPosition.back),
-                mirrorFrontCamera: mirrorFrontCamera,
               ),
-          mirrorFrontCamera: mirrorFrontCamera,
           exifPreferences: exifPreferences,
           enableAudio: enableAudio,
           enablePhysicalButton: enablePhysicalButton,
@@ -238,7 +232,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
                 sensor: Sensor.position(SensorPosition.back),
                 mirrorFrontCamera: mirrorFrontCamera,
               ),
-          mirrorFrontCamera: mirrorFrontCamera,
           enablePhysicalButton: enablePhysicalButton,
           exifPreferences: exifPreferences,
           enableAudio: enableAudio,
@@ -275,7 +268,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
   }) : this._(
           sensorConfig: sensorConfig ??
               SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
-          mirrorFrontCamera: false,
           enablePhysicalButton: false,
           exifPreferences: null,
           enableAudio: false,
@@ -314,7 +306,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
   }) : this._(
           sensorConfig: sensorConfig ??
               SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
-          mirrorFrontCamera: false,
           enablePhysicalButton: false,
           exifPreferences: null,
           enableAudio: false,


### PR DESCRIPTION
## Description

`SensorConfig` already contained:
- list of sensors
- flash mode
- aspect ratio
- zoom
- mirrorFrontCamera

Now it has `single` and `multiple` constructors to set one or multiple sensors.
The parameters that `SensorConfig` already contain have been removed from `CameraAwesomeBuilder`.

Now, one could use CamerAwesome like this:
```dart
CameraAwesomeBuilder.awesome(
     saveConfig: SaveConfig.photoAndVideo(
      photoPathBuilder: () => path(CaptureMode.photo),
      videoPathBuilder: () => path(CaptureMode.video),
      initialCaptureMode: CaptureMode.video,
    ),
    sensorConfig: SensorConfig.single(
      sensor: Sensor.position(SensorPosition.back),
      flashMode: FlashMode.auto,
      zoom: 0.5,
      aspectRatio: CameraAspectRatios.ratio_1_1,
      mirrorFrontCamera: true,
    ),
)
```

Or even:
```dart
CameraAwesomeBuilder.awesome(
     saveConfig: SaveConfig.photoAndVideo(
      photoPathBuilder: () => path(CaptureMode.photo),
      videoPathBuilder: () => path(CaptureMode.video),
      initialCaptureMode: CaptureMode.video,
    ),
);
```
In this case, the default configuration is used (back sensor, no flash, no zoom, aspect ratio 4:3, mirroFrontCamera = false).


Notes:
- Changing parameters of `SensorConfig` (e.g.: flash) call native code to make the change.
- If the `SensorConfig` is not the currently used `SensorConfig`, it might have unpredictable behaviour.
- The initial parameters of `SensorConfig` builder don't actually call native code since the camera might not have been setup yet.


**Next step:** make `SaveConfig` compatible with web and multi camera.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [x] 🛠 My feature contain breaking change.

`CameraAwesomeBuilder` now takes a `SensorConfig` instead of the several parameters it already has.