### PR TITLE
✨ Ability to mirror video recording for front camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Here is the complete changelog:
 - ✨ Users can now pass options (such as bitrate, fps, and quality) when recording a video.
 - ✨🍏 Implemented brightness and exposure level settings on iOS / iPadOS.
 - ✨🤖 Added zoom indicator UI.
+- ✨🤖 Video recording is now mirrored if `mirrorFrontCamera` is set to true.
 - ♻️🍏 Completely reworked the code for increased clarity and performance.
 - 🐛 Fixed patrol tests.
 - 🐛 Fixed the use of capture button parameter in awesome bottom actions (thanks to @juliuszmandrosz).

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
@@ -294,7 +294,9 @@ data class CameraXState(
             recorderBuilder.setTargetVideoEncodingBitRate(videoOptions.bitrate.toInt())
         }
         val recorder = recorderBuilder.build()
-        return VideoCapture.withOutput(recorder)
+        return VideoCapture.Builder<Recorder>(recorder)
+            .setMirrorMode(if (mirrorFrontCamera) MirrorMode.MIRROR_MODE_ON_FRONT_ONLY else MirrorMode.MIRROR_MODE_OFF)
+            .build()
     }
 
     @SuppressLint("RestrictedApi")

--- a/docs/getting_started/awesome-ui.mdx
+++ b/docs/getting_started/awesome-ui.mdx
@@ -55,7 +55,10 @@ SaveConfig.photoAndVideo(
       fallbackStrategy: QualityFallbackStrategy.lower,
     ),
   ),
+  // 5.
   exifPreferences: ExifPreferences(saveGPSLocation: true),
+  // 6.
+  mirrorFrontCamera: true,
 )
 ```
 
@@ -65,6 +68,8 @@ Let's break it down:
 2. You can customize the path where your photos will be saved.
 3. You can also customize where to save your videos.
 4. The video recording can be customized using `VideoOptions`. Note that each platform has its own settings.
+5. You can also enable or disable the GPS location in the EXIF data of your photos.
+6. Set if you want the front camera pictures & videos to be mirrored like in the preview.
 
 A `photoPathBuilder` could look like this:
 
@@ -115,20 +120,18 @@ CameraAwesomeBuilder.awesome(
   sensorConfig: SensorConfig.single(
     aspectRatio: CameraAspectRatios.ratio_4_3,
     flashMode: FlashMode.auto,
-    mirrorFrontCamera: true,
     sensor: Sensor.position(SensorPosition.back),
     zoom: 0.0,
   ),
 )
 ```
 
-| Parameter             | Description                                      |
-| --------------------- | ------------------------------------------------ |
-| **aspectRatio**       | Initial aspect ratio of photos and videos taken  |
-| **flashMode**         | The initial flash mode                           |
-| **mirrorFrontCamera** | Whether to mirror the front camera or not        |
-| **sensor**            | The initial camera sensor (Back or Front)        |
-| **zoom**              | A value between 0.0 (no zoom) and 1.0 (max zoom) |
+| Parameter       | Description                                      |
+| --------------- | ------------------------------------------------ |
+| **aspectRatio** | Initial aspect ratio of photos and videos taken  |
+| **flashMode**   | The initial flash mode                           |
+| **sensor**      | The initial camera sensor (Back or Front)        |
+| **zoom**        | A value between 0.0 (no zoom) and 1.0 (max zoom) |
 
 Note: you might also notice the `SensorConfig.multiple()` constructor which lets you specify several sensors.
 This feature is in beta, but you can take a look at the [dedicated documentation](/getting_started/multicam).
@@ -471,6 +474,7 @@ CameraAwesomeBuilder.awesome(
    // Define if you want to take photos, videos or both and where to save them
   saveConfig: SaveConfig.photoAndVideo(
     initialCaptureMode: CaptureMode.photo,
+    mirrorFrontCamera: true,
     photoPathBuilder: (sensors) async {
       // Return a valid file path (must be a jpg file)
       return SingleCaptureRequest('some/image/file/path.jpg', sensors.first);
@@ -484,7 +488,6 @@ CameraAwesomeBuilder.awesome(
   sensorConfig: SensorConfig.single(
     aspectRatio: CameraAspectRatios.ratio_4_3,
     flashMode: FlashMode.auto,
-    mirrorFrontCamera: true,
     sensor: Sensor.position(SensorPosition.back),
     zoom: 0.0,
   ),
@@ -528,28 +531,27 @@ CameraAwesomeBuilder.awesome(
 
 ### 🔬 Full list of properties
 
-| Method                      | Comment                                                                                                                                               |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **aspectRatio**             | Initial aspect ratio of photos and videos taken                                                                                                       |
-| **bottomActionsBuilder**    | A widget builder used to show buttons on the bottom of the preview.<br/>`AwesomeBottomActions` by default.                                            |
-| **enablePhysicalButton**    | When set to true, volume buttons will capture pictures/videos depending on the current mode.                                                          |
-| **filter**                  | Initial preview filter which will be applied to the photo                                                                                             |
-| **imageAnalysisConfig**     | Image format, resolution and autoStart (start analysis immediately or later)                                                                          |
-| **middleContentBuilder**    | A widget builder used to add widgets above the middle part of the preview (between bottom and top actions).<br/>Shows the filter selector by default. |
-| **mirrorFrontCamera**       | Activate to mirror the pictures taken with the front camera                                                                                           |
-| **onImageForAnalysis**      | Callback that will provide an image stream for AI analysis                                                                                            |
-| **onMediaTap**              | Choose what you want to do when user tap on the last media captured                                                                                   |
-| **onPreviewTapBuilder**     | Customize the behavior when the camera preview is tapped (tap to focus by default)                                                                    |
-| **onPreviewScaleBuilder**   | Customize what to do when the user makes a pinch (pinch to zoom by default)                                                                           |
-| **previewAlignment**        | Alignment of the preview                                                                                                                              |
-| **previewDecoratorBuilder** | A widget builder used to draw elements around or on top of the preview                                                                                |
-| **previewFit**              | One of fitWidth, fitHeight, contain, cover                                                                                                            |
-| **previewPadding**          | Padding around the preview                                                                                                                            |
-| **progressIndicator**       | Widget to show when loading                                                                                                                           |
-| **saveConfig**              | Define if you want to take photos, videos or both and where to save them. You can also set exif preferences and video recording settings.             |
-| **sensorConfig**            | The initial sensor configuration: aspect ratio, flash mode, wether you want to mirror the front camera, which sensor to use and initial zoom.         |
-| **theme**                   | Theme used to customize the built-in UI                                                                                                               |
-| **topActionsBuilder**       | A widget builder used to show buttons on the top of the preview.<br/>`AwesomeTopActions` by default.                                                  |
+| Method                      | Comment                                                                                                                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **aspectRatio**             | Initial aspect ratio of photos and videos taken                                                                                                                                             |
+| **bottomActionsBuilder**    | A widget builder used to show buttons on the bottom of the preview.<br/>`AwesomeBottomActions` by default.                                                                                  |
+| **enablePhysicalButton**    | When set to true, volume buttons will capture pictures/videos depending on the current mode.                                                                                                |
+| **filter**                  | Initial preview filter which will be applied to the photo                                                                                                                                   |
+| **imageAnalysisConfig**     | Image format, resolution and autoStart (start analysis immediately or later)                                                                                                                |
+| **middleContentBuilder**    | A widget builder used to add widgets above the middle part of the preview (between bottom and top actions).<br/>Shows the filter selector by default.                                       |
+| **onImageForAnalysis**      | Callback that will provide an image stream for AI analysis                                                                                                                                  |
+| **onMediaTap**              | Choose what you want to do when user tap on the last media captured                                                                                                                         |
+| **onPreviewTapBuilder**     | Customize the behavior when the camera preview is tapped (tap to focus by default)                                                                                                          |
+| **onPreviewScaleBuilder**   | Customize what to do when the user makes a pinch (pinch to zoom by default)                                                                                                                 |
+| **previewAlignment**        | Alignment of the preview                                                                                                                                                                    |
+| **previewDecoratorBuilder** | A widget builder used to draw elements around or on top of the preview                                                                                                                      |
+| **previewFit**              | One of fitWidth, fitHeight, contain, cover                                                                                                                                                  |
+| **previewPadding**          | Padding around the preview                                                                                                                                                                  |
+| **progressIndicator**       | Widget to show when loading                                                                                                                                                                 |
+| **saveConfig**              | Define if you want to take photos, videos or both and where to save them. You can also set exif preferences, decide to mirror or not front camera outputs and set video recording settings. |
+| **sensorConfig**            | The initial sensor configuration: aspect ratio, flash mode, which sensor to use and initial zoom.                                                                                           |
+| **theme**                   | Theme used to customize the built-in UI                                                                                                                                                     |
+| **topActionsBuilder**       | A widget builder used to show buttons on the top of the preview.<br/>`AwesomeTopActions` by default.                                                                                        |
 
 ## 🔨 Need more customization? Other use cases?
 

--- a/docs/getting_started/custom-ui.mdx
+++ b/docs/getting_started/custom-ui.mdx
@@ -23,23 +23,23 @@ You can find more examples on the `example` folder.
 
 ## Properties
 
-| Method                    | Comment                                                                                                                                       |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **aspectRatio**           | Initial aspect ratio of photos and videos taken                                                                                               |
-| **builder**               | Create your own interface using the builder method.                                                                                           |
-| **enablePhysicalButton**  | When set to true, volume buttons will capture pictures/videos depending on the current mode.                                                  |
-| **filter**                | Initial preview filter which will be applied to the photo                                                                                     |
-| **imageAnalysisConfig**   | Image format, resolution and autoStart (start analysis immediately or later)                                                                  |
-| **onImageForAnalysis**    | Callback that will provide an image stream for AI analysis                                                                                    |
-| **onPreviewTapBuilder**   | Customize the behavior when the camera preview is tapped (tap to focus by default)                                                            |
-| **onPreviewScaleBuilder** | Customize what to do when the user makes a pinch (pinch to zoom by default)                                                                   |
-| **previewAlignment**      | Alignment of the preview                                                                                                                      |
-| **previewFit**            | One of fitWidth, fitHeight, contain, cover                                                                                                    |
-| **previewPadding**        | Padding around the preview                                                                                                                    |
-| **progressIndicator**     | Widget to show when loading                                                                                                                   |
-| **saveConfig**            | Define if you want to take photos, videos or both and where to save them                                                                      |
-| **sensorConfig**          | The initial sensor configuration: aspect ratio, flash mode, wether you want to mirror the front camera, which sensor to use and initial zoom. |
-| **theme**                 | Theme used to customize the built-in UI                                                                                                       |
+| Method                    | Comment                                                                                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **aspectRatio**           | Initial aspect ratio of photos and videos taken                                                                                                                                             |
+| **builder**               | Create your own interface using the builder method.                                                                                                                                         |
+| **enablePhysicalButton**  | When set to true, volume buttons will capture pictures/videos depending on the current mode.                                                                                                |
+| **filter**                | Initial preview filter which will be applied to the photo                                                                                                                                   |
+| **imageAnalysisConfig**   | Image format, resolution and autoStart (start analysis immediately or later)                                                                                                                |
+| **onImageForAnalysis**    | Callback that will provide an image stream for AI analysis                                                                                                                                  |
+| **onPreviewTapBuilder**   | Customize the behavior when the camera preview is tapped (tap to focus by default)                                                                                                          |
+| **onPreviewScaleBuilder** | Customize what to do when the user makes a pinch (pinch to zoom by default)                                                                                                                 |
+| **previewAlignment**      | Alignment of the preview                                                                                                                                                                    |
+| **previewFit**            | One of fitWidth, fitHeight, contain, cover                                                                                                                                                  |
+| **previewPadding**        | Padding around the preview                                                                                                                                                                  |
+| **progressIndicator**     | Widget to show when loading                                                                                                                                                                 |
+| **saveConfig**            | Define if you want to take photos, videos or both and where to save them. You can also set exif preferences, decide to mirror or not front camera outputs and set video recording settings. |
+| **sensorConfig**          | The initial sensor configuration: aspect ratio, flash mode, which sensor to use and initial zoom.                                                                                           |
+| **theme**                 | Theme used to customize the built-in UI                                                                                                                                                     |
 
 ## Builder method
 

--- a/docs/migration_guides/from_1_to_2.mdx
+++ b/docs/migration_guides/from_1_to_2.mdx
@@ -23,7 +23,6 @@ CameraAwesomeBuilder.awesome(
 +       sensor: Sensor.position(SensorPosition.back),
 +       flashMode: FlashMode.auto,
 +       aspectRatio: CameraAspectRatios.ratio_4_3,
-+       mirrorFrontCamera: true,
 +       zoom: 0.0,
 +   ),
 -   exifPreferences: ExifPreferences(saveGPSLocation: true),
@@ -65,6 +64,7 @@ CameraAwesomeBuilder.awesome(
 +         ),
 +       ),
 +       exifPreferences: ExifPreferences(saveGPSLocation: true),
++       mirrorFrontCamera: true,
      ),
     ...
 )
@@ -77,6 +77,7 @@ CameraAwesomeBuilder.awesome(
 - ✨ Users can now pass options (such as bitrate, fps, and quality) when recording a video.
 - ✨🍏 Implemented brightness and exposure level settings on iOS / iPadOS.
 - ✨🤖 Added zoom indicator UI.
+- ✨🤖 Video recording is now mirrored if `mirrorFrontCamera` is set to true.
 - ♻️🍏 Completely reworked the code for increased clarity and performance.
 - 🐛 Fixed patrol tests.
 - 🐛 Fixed the use of capture button parameter in awesome bottom actions (thanks to @juliuszmandrosz).

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -265,7 +265,7 @@ DEPENDENCIES:
   - google_mlkit_face_detection (from `.symlinks/plugins/google_mlkit_face_detection/ios`)
   - google_mlkit_text_recognition (from `.symlinks/plugins/google_mlkit_text_recognition/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - patrol (from `.symlinks/plugins/patrol/ios`)
   - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/ios`)
 
@@ -332,7 +332,7 @@ EXTERNAL SOURCES:
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   patrol:
     :path: ".symlinks/plugins/patrol/ios"
   video_player_avfoundation:
@@ -362,7 +362,7 @@ SPEC CHECKSUMS:
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
   gRPC-Swift: 74adcaaa62ac5e0a018938840328cb1fdfb09e7b
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
+  integration_test: 13825b8a9334a850581300559b8839134b124670
   JPSVolumeButtonHandler: 53110330c9168ed325def93eabff39f0fe3e8082
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
   MLImage: 489dfec109f21da8621b28d476401aaf7a0d4ff4

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,7 @@ class CameraPage extends StatelessWidget {
         child: CameraAwesomeBuilder.awesome(
           saveConfig: SaveConfig.photoAndVideo(
             initialCaptureMode: CaptureMode.photo,
+            mirrorFrontCamera: true,
             photoPathBuilder: (sensors) async {
               final Directory extDir = await getTemporaryDirectory();
               final testDir = await Directory(
@@ -70,7 +71,6 @@ class CameraPage extends StatelessWidget {
             sensor: Sensor.position(SensorPosition.back),
             flashMode: FlashMode.auto,
             aspectRatio: CameraAspectRatios.ratio_4_3,
-            mirrorFrontCamera: true,
             zoom: 0.0,
           ),
           enablePhysicalButton: true,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   better_open_file:
     dependency: "direct main"
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -76,10 +76,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   colorfilter_generator:
     dependency: transitive
     description:
@@ -290,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -338,18 +338,18 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: "direct main"
     description:
@@ -519,10 +519,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -583,18 +583,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.3.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   win32:
     dependency: transitive
     description:
@@ -620,5 +620,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.18.2 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -43,6 +43,9 @@
   [self initCameraPreview:sensor];
   
   [_captureConnection setAutomaticallyAdjustsVideoMirroring:NO];
+  if (mirrorFrontCamera && [_captureConnection isVideoMirroringSupported]) {
+    [_captureConnection setVideoMirrored:mirrorFrontCamera];
+  }
   
   _captureMode = captureMode;
   
@@ -304,6 +307,10 @@
 
 - (void)setMirrorFrontCamera:(bool)value error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
   _mirrorFrontCamera = value;
+  
+  if ([_captureConnection isVideoMirroringSupported]) {
+      [_captureConnection setVideoMirrored:value];
+  }
 }
 
 /// Set flash mode

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -177,6 +177,7 @@ class CamerawesomePlugin {
     CaptureMode captureMode = CaptureMode.photo,
     required ExifPreferences exifPreferences,
     required VideoOptions? videoOptions,
+    required bool mirrorFrontCamera,
   }) async {
     return CameraInterface()
         .setupCamera(
@@ -185,7 +186,7 @@ class CamerawesomePlugin {
           }).toList(),
           sensorConfig.aspectRatio.name.toUpperCase(),
           sensorConfig.zoom,
-          sensorConfig.mirrorFrontCamera,
+          mirrorFrontCamera,
           enablePhysicalButton,
           sensorConfig.flashMode.name.toUpperCase(),
           captureMode.name.toUpperCase(),

--- a/lib/src/orchestrator/models/save_config.dart
+++ b/lib/src/orchestrator/models/save_config.dart
@@ -1,6 +1,6 @@
+import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:camerawesome/pigeon.dart';
 import 'package:camerawesome/src/orchestrator/file/builder/capture_request_builder.dart';
-import 'package:camerawesome/src/orchestrator/models/models.dart';
 
 typedef CaptureRequestBuilder = Future<CaptureRequest> Function(
     List<Sensor> sensors);
@@ -11,6 +11,7 @@ class SaveConfig {
   final List<CaptureMode> captureModes;
   final CaptureMode initialCaptureMode;
   final VideoOptions? videoOptions;
+  final bool mirrorFrontCamera;
 
   /// Choose if you want to persist user location in image metadata or not
   final ExifPreferences? exifPreferences;
@@ -22,12 +23,14 @@ class SaveConfig {
     required this.initialCaptureMode,
     this.videoOptions,
     this.exifPreferences,
+    required this.mirrorFrontCamera,
   });
 
   /// You only want to take photos
   SaveConfig.photo({
     CaptureRequestBuilder? pathBuilder,
     ExifPreferences? exifPreferences,
+    bool mirrorFrontCamera = false,
   }) : this._(
           photoPathBuilder: pathBuilder ??
               (sensors) => AwesomeCaptureRequestBuilder()
@@ -35,12 +38,14 @@ class SaveConfig {
           captureModes: [CaptureMode.photo],
           initialCaptureMode: CaptureMode.photo,
           exifPreferences: exifPreferences,
+          mirrorFrontCamera: mirrorFrontCamera,
         );
 
   /// You only want to take videos
   SaveConfig.video({
     CaptureRequestBuilder? pathBuilder,
     VideoOptions? videoOptions,
+    bool mirrorFrontCamera = false,
   }) : this._(
           videoPathBuilder: pathBuilder ??
               (sensors) => AwesomeCaptureRequestBuilder()
@@ -48,6 +53,7 @@ class SaveConfig {
           captureModes: [CaptureMode.video],
           initialCaptureMode: CaptureMode.video,
           videoOptions: videoOptions,
+          mirrorFrontCamera: mirrorFrontCamera,
         );
 
   /// You want to be able to take both photos and videos
@@ -57,6 +63,7 @@ class SaveConfig {
     CaptureMode initialCaptureMode = CaptureMode.photo,
     VideoOptions? videoOptions,
     ExifPreferences? exifPreferences,
+    bool mirrorFrontCamera = false,
   }) : this._(
           photoPathBuilder: photoPathBuilder ??
               (sensors) => AwesomeCaptureRequestBuilder()
@@ -68,5 +75,6 @@ class SaveConfig {
           initialCaptureMode: initialCaptureMode,
           videoOptions: videoOptions,
           exifPreferences: exifPreferences,
+          mirrorFrontCamera: mirrorFrontCamera,
         );
 }

--- a/lib/src/orchestrator/models/sensor_config.dart
+++ b/lib/src/orchestrator/models/sensor_config.dart
@@ -11,11 +11,7 @@ class SensorConfig {
 
   late BehaviorSubject<SensorType> _sensorTypeController;
 
-  late BehaviorSubject<bool> _mirrorFrontCameraController;
-
   late Stream<FlashMode> flashMode$;
-
-  late Stream<bool> mirrorFrontCamera$;
 
   late Stream<SensorType> sensorType$;
 
@@ -45,13 +41,11 @@ class SensorConfig {
   SensorConfig.single({
     Sensor? sensor,
     FlashMode flashMode = FlashMode.none,
-    bool mirrorFrontCamera = false,
     double zoom = 0.0,
     CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
   }) : this._(
           sensors: [sensor ?? Sensor.position(SensorPosition.back)],
           flash: flashMode,
-          mirrorFrontCamera: mirrorFrontCamera,
           currentZoom: zoom,
           aspectRatio: aspectRatio,
         );
@@ -59,13 +53,11 @@ class SensorConfig {
   SensorConfig.multiple({
     required List<Sensor> sensors,
     FlashMode flashMode = FlashMode.none,
-    bool mirrorFrontCamera = false,
     double zoom = 0.0,
     CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
   }) : this._(
           sensors: sensors,
           flash: flashMode,
-          mirrorFrontCamera: mirrorFrontCamera,
           currentZoom: zoom,
           aspectRatio: aspectRatio,
         );
@@ -73,7 +65,6 @@ class SensorConfig {
   SensorConfig._({
     required this.sensors,
     FlashMode flash = FlashMode.none,
-    bool mirrorFrontCamera = false,
     CameraAspectRatios aspectRatio = CameraAspectRatios.ratio_4_3,
 
     /// Zoom must be between 0.0 (no zoom) and 1.0 (max zoom)
@@ -81,10 +72,6 @@ class SensorConfig {
   }) {
     _flashModeController = BehaviorSubject<FlashMode>.seeded(flash);
     flashMode$ = _flashModeController.stream;
-
-    _mirrorFrontCameraController =
-        BehaviorSubject<bool>.seeded(mirrorFrontCamera);
-    mirrorFrontCamera$ = _mirrorFrontCameraController.stream;
 
     _sensorTypeController = BehaviorSubject<SensorType>.seeded(
         sensors.first?.type ?? SensorType.wideAngle);
@@ -112,9 +99,6 @@ class SensorConfig {
   /// Returns the current zoom without stream
   double get zoom => _zoomController.value;
 
-  /// Return the current mirrorFrontCamera without stream
-  bool get mirrorFrontCamera => _mirrorFrontCameraController.value;
-
   /// Set manually the [FlashMode] between
   /// [FlashMode.none] no flash
   /// [FlashMode.on] always flashing when taking photo
@@ -123,12 +107,6 @@ class SensorConfig {
   Future<void> setFlashMode(FlashMode flashMode) async {
     await CamerawesomePlugin.setFlashMode(flashMode);
     _flashModeController.sink.add(flashMode);
-  }
-
-  /// Set mirroring front camera (for selfie for ex.)
-  Future<void> setMirrorFrontCamera(bool mirrorFrontCamera) async {
-    await CamerawesomePlugin.setMirrorFrontCamera(mirrorFrontCamera);
-    _mirrorFrontCameraController.sink.add(mirrorFrontCamera);
   }
 
   /// Returns the current flash mode without stream
@@ -197,7 +175,6 @@ class SensorConfig {
     _brightnessController.close();
     _sensorTypeController.close();
     _zoomController.close();
-    _mirrorFrontCameraController.close();
     _flashModeController.close();
     _aspectRatioController.close();
   }

--- a/lib/src/orchestrator/states/preparing_camera_state.dart
+++ b/lib/src/orchestrator/states/preparing_camera_state.dart
@@ -194,6 +194,7 @@ class PreparingCameraState extends CameraState {
       captureMode: nextCaptureMode,
       exifPreferences: cameraContext.exifPreferences,
       videoOptions: saveConfig?.videoOptions,
+      mirrorFrontCamera: saveConfig?.mirrorFrontCamera ?? false,
     );
     _isReady = true;
     return _isReady;

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -213,7 +213,6 @@ class CameraAwesomeBuilder extends StatefulWidget {
           sensorConfig: sensorConfig ??
               SensorConfig.single(
                 sensor: Sensor.position(SensorPosition.back),
-                mirrorFrontCamera: mirrorFrontCamera,
               ),
           enablePhysicalButton: enablePhysicalButton,
           progressIndicator: progressIndicator,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   colorfilter_generator:
     dependency: "direct main"
     description:
@@ -175,10 +175,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -191,10 +191,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -215,10 +215,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   package_config:
     dependency: transitive
     description:
@@ -231,10 +231,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: "direct main"
     description:
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -457,5 +457,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
## Description

`mirrorFrontCamera` only allowed to mirror pictures taken.
With this PR, it also mirror video recordings when set to true.

|Feature | Android | iOS |
|-|-|-|
|Mirror video recording|✅|✅|

Fixes #331

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change
hgb
- [x] 🛠 My feature contain breaking change.

I moved the `mirrorFrontCamera` to the `SaveConfig` object since it is not a sensor specific setting. All sensors must respect that parameter.