### PR TITLE
Add `VideoRecordingQuality` option to iOS video recordings

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -155,6 +155,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
             currentCaptureMode = mode,
             enableImageStream = enableImageStream,
             videoOptions = videoOptions?.android,
+            videoRecordingQuality = videoOptions?.quality,
             onStreamReady = { state -> state.updateLifecycle(activity!!) }).apply {
             this.updateAspectRatio(aspectRatio)
             this.flashMode = FlashMode.valueOf(flashMode)

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
@@ -47,6 +47,7 @@ data class CameraXState(
     var flashMode: FlashMode = FlashMode.NONE,
     val onStreamReady: (state: CameraXState) -> Unit,
     var mirrorFrontCamera: Boolean = false,
+    val videoRecordingQuality: VideoRecordingQuality?,
     val videoOptions: AndroidVideoOptions?,
 ) : EventChannel.StreamHandler, SensorOrientation {
 
@@ -271,8 +272,8 @@ data class CameraXState(
     private fun buildVideoCapture(videoOptions: AndroidVideoOptions?): VideoCapture<Recorder> {
         val recorderBuilder = Recorder.Builder()
         // Aspect ratio is handled by the setViewPort on the UseCaseGroup
-        if (videoOptions?.quality != null) {
-            val quality = when (videoOptions.quality) {
+        if (videoRecordingQuality != null) {
+            val quality = when (videoRecordingQuality) {
                 VideoRecordingQuality.LOWEST -> Quality.LOWEST
                 VideoRecordingQuality.SD -> Quality.SD
                 VideoRecordingQuality.HD -> Quality.HD
@@ -283,7 +284,7 @@ data class CameraXState(
             recorderBuilder.setQualitySelector(
                 QualitySelector.from(
                     quality,
-                    if (videoOptions.fallbackStrategy == QualityFallbackStrategy.LOWER) FallbackStrategy.lowerQualityOrHigherThan(
+                    if (videoOptions?.fallbackStrategy == QualityFallbackStrategy.LOWER) FallbackStrategy.lowerQualityOrHigherThan(
                         quality
                     )
                     else FallbackStrategy.higherQualityOrLowerThan(quality)

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
@@ -266,6 +266,8 @@ data class PigeonSensor (
 data class VideoOptions (
   /** Enable audio while video recording */
   val enableAudio: Boolean,
+  /** The quality of the video recording, defaults to [VideoRecordingQuality.highest]. */
+  val quality: VideoRecordingQuality? = null,
   val android: AndroidVideoOptions? = null,
   val ios: CupertinoVideoOptions? = null
 
@@ -274,18 +276,22 @@ data class VideoOptions (
     @Suppress("UNCHECKED_CAST")
     fun fromList(list: List<Any?>): VideoOptions {
       val enableAudio = list[0] as Boolean
-      val android: AndroidVideoOptions? = (list[1] as List<Any?>?)?.let {
+      val quality: VideoRecordingQuality? = (list[1] as Int?)?.let {
+        VideoRecordingQuality.ofRaw(it)
+      }
+      val android: AndroidVideoOptions? = (list[2] as List<Any?>?)?.let {
         AndroidVideoOptions.fromList(it)
       }
-      val ios: CupertinoVideoOptions? = (list[2] as List<Any?>?)?.let {
+      val ios: CupertinoVideoOptions? = (list[3] as List<Any?>?)?.let {
         CupertinoVideoOptions.fromList(it)
       }
-      return VideoOptions(enableAudio, android, ios)
+      return VideoOptions(enableAudio, quality, android, ios)
     }
   }
   fun toList(): List<Any?> {
     return listOf<Any?>(
       enableAudio,
+      quality?.raw,
       android?.toList(),
       ios?.toList(),
     )
@@ -299,8 +305,6 @@ data class AndroidVideoOptions (
    * desired.
    */
   val bitrate: Long? = null,
-  /** The quality of the video recording, defaults to [VideoRecordingQuality.highest]. */
-  val quality: VideoRecordingQuality? = null,
   val fallbackStrategy: QualityFallbackStrategy? = null
 
 ) {
@@ -308,19 +312,15 @@ data class AndroidVideoOptions (
     @Suppress("UNCHECKED_CAST")
     fun fromList(list: List<Any?>): AndroidVideoOptions {
       val bitrate = list[0].let { if (it is Int) it.toLong() else it as Long? }
-      val quality: VideoRecordingQuality? = (list[1] as Int?)?.let {
-        VideoRecordingQuality.ofRaw(it)
-      }
-      val fallbackStrategy: QualityFallbackStrategy? = (list[2] as Int?)?.let {
+      val fallbackStrategy: QualityFallbackStrategy? = (list[1] as Int?)?.let {
         QualityFallbackStrategy.ofRaw(it)
       }
-      return AndroidVideoOptions(bitrate, quality, fallbackStrategy)
+      return AndroidVideoOptions(bitrate, fallbackStrategy)
     }
   }
   fun toList(): List<Any?> {
     return listOf<Any?>(
       bitrate,
-      quality?.raw,
       fallbackStrategy?.raw,
     )
   }

--- a/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.h
+++ b/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.h
@@ -53,6 +53,7 @@ AVCaptureAudioDataOutputSampleBufferDelegate>
 @property(readonly, nonatomic) NSString *currentPresset;
 @property(readonly, nonatomic) AspectRatio aspectRatio;
 @property(readonly, nonatomic) CupertinoVideoOptions *videoOptions;
+@property(readonly, nonatomic) VideoRecordingQuality recordingQuality;
 @property(readonly, nonatomic) CameraPreviewTexture* previewTexture;
 @property(readonly, nonatomic) bool saveGPSLocation;
 @property(readonly, nonatomic) bool mirrorFrontCamera;
@@ -67,6 +68,7 @@ AVCaptureAudioDataOutputSampleBufferDelegate>
 
 - (instancetype)initWithCameraSensor:(PigeonSensorPosition)sensor
                         videoOptions:(nullable CupertinoVideoOptions *)videoOptions
+                    recordingQuality:(VideoRecordingQuality)recordingQuality
                         streamImages:(BOOL)streamImages
                    mirrorFrontCamera:(BOOL)mirrorFrontCamera
                 enablePhysicalButton:(BOOL)enablePhysicalButton

--- a/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/Classes/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -13,6 +13,7 @@
 
 - (instancetype)initWithCameraSensor:(PigeonSensorPosition)sensor
                         videoOptions:(nullable CupertinoVideoOptions *)videoOptions
+                    recordingQuality:(VideoRecordingQuality)recordingQuality
                         streamImages:(BOOL)streamImages
                    mirrorFrontCamera:(BOOL)mirrorFrontCamera
                 enablePhysicalButton:(BOOL)enablePhysicalButton
@@ -31,6 +32,7 @@
   _aspectRatio = aspectRatioMode;
   _mirrorFrontCamera = mirrorFrontCamera;
   _videoOptions = videoOptions;
+  _recordingQuality = recordingQuality;
   
   // Creating capture session
   _captureSession = [[AVCaptureSession alloc] init];
@@ -479,7 +481,7 @@
       [self->_captureVideoOutput setSampleBufferDelegate:self queue:self->_dispatchQueue];
       
       completion(nil);
-    } options:_videoOptions completion:completion];
+    } options:_videoOptions quality: _recordingQuality completion:completion];
   } else {
     completion([FlutterError errorWithCode:@"VIDEO_ERROR" message:@"already recording video" details:@""]);
   }

--- a/ios/Classes/CamerawesomePlugin.m
+++ b/ios/Classes/CamerawesomePlugin.m
@@ -124,6 +124,7 @@ FlutterEventSink physicalButtonEventSink;
     PigeonSensor *firstSensor = sensors.firstObject;
     self.camera = [[SingleCameraPreview alloc] initWithCameraSensor:firstSensor.position
                                                        videoOptions:videoOptions != nil ? videoOptions.ios : nil
+                                                   recordingQuality:videoOptions != nil ? videoOptions.quality : VideoRecordingQualityHighest
                                                        streamImages:[enableImageStream boolValue]
                                                   mirrorFrontCamera:[mirrorFrontCamera boolValue]
                                                enablePhysicalButton:[enablePhysicalButton boolValue]

--- a/ios/Classes/Controllers/Video/VideoController.h
+++ b/ios/Classes/Controllers/Video/VideoController.h
@@ -21,6 +21,7 @@ typedef void(^OnVideoWriterSetup)(void);
 @property(readonly, nonatomic) bool isPaused;
 @property(readonly, nonatomic) bool isAudioEnabled;
 @property(readonly, nonatomic) bool isAudioSetup;
+@property(readonly, nonatomic) VideoRecordingQuality recordingQuality;
 @property(readonly, nonatomic) CupertinoVideoOptions *options;
 @property NSInteger orientation;
 @property(readonly, nonatomic) AVCaptureDevice *captureDevice;
@@ -37,7 +38,7 @@ typedef void(^OnVideoWriterSetup)(void);
 @property(assign, nonatomic) CMTime audioTimeOffset;
 
 - (instancetype)init;
-- (void)recordVideoAtPath:(NSString *)path captureDevice:(AVCaptureDevice *)device orientation:(NSInteger)orientation audioSetupCallback:(OnAudioSetup)audioSetupCallback videoWriterCallback:(OnVideoWriterSetup)videoWriterCallback options:(CupertinoVideoOptions *)options completion:(nonnull void (^)(FlutterError * _Nullable))completion;
+- (void)recordVideoAtPath:(NSString *)path captureDevice:(AVCaptureDevice *)device orientation:(NSInteger)orientation audioSetupCallback:(OnAudioSetup)audioSetupCallback videoWriterCallback:(OnVideoWriterSetup)videoWriterCallback options:(CupertinoVideoOptions *)options quality:(VideoRecordingQuality)quality completion:(nonnull void (^)(FlutterError * _Nullable))completion;
 - (void)stopRecordingVideo:(nonnull void (^)(NSNumber * _Nullable, FlutterError * _Nullable))completion;
 - (void)pauseVideoRecording;
 - (void)resumeVideoRecording;

--- a/ios/Classes/Pigeon/Pigeon.h
+++ b/ios/Classes/Pigeon/Pigeon.h
@@ -141,23 +141,23 @@ typedef NS_ENUM(NSUInteger, AnalysisRotation) {
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithEnableAudio:(NSNumber *)enableAudio
+    quality:(VideoRecordingQuality)quality
     android:(nullable AndroidVideoOptions *)android
     ios:(nullable CupertinoVideoOptions *)ios;
 /// Enable audio while video recording
 @property(nonatomic, strong) NSNumber * enableAudio;
+/// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
+@property(nonatomic, assign) VideoRecordingQuality quality;
 @property(nonatomic, strong, nullable) AndroidVideoOptions * android;
 @property(nonatomic, strong, nullable) CupertinoVideoOptions * ios;
 @end
 
 @interface AndroidVideoOptions : NSObject
 + (instancetype)makeWithBitrate:(nullable NSNumber *)bitrate
-    quality:(VideoRecordingQuality)quality
     fallbackStrategy:(QualityFallbackStrategy)fallbackStrategy;
 /// The bitrate of the video recording. Only set it if a custom bitrate is
 /// desired.
 @property(nonatomic, strong, nullable) NSNumber * bitrate;
-/// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
-@property(nonatomic, assign) VideoRecordingQuality quality;
 @property(nonatomic, assign) QualityFallbackStrategy fallbackStrategy;
 @end
 

--- a/ios/Classes/Pigeon/Pigeon.m
+++ b/ios/Classes/Pigeon/Pigeon.m
@@ -167,10 +167,12 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 
 @implementation VideoOptions
 + (instancetype)makeWithEnableAudio:(NSNumber *)enableAudio
+    quality:(VideoRecordingQuality)quality
     android:(nullable AndroidVideoOptions *)android
     ios:(nullable CupertinoVideoOptions *)ios {
   VideoOptions* pigeonResult = [[VideoOptions alloc] init];
   pigeonResult.enableAudio = enableAudio;
+  pigeonResult.quality = quality;
   pigeonResult.android = android;
   pigeonResult.ios = ios;
   return pigeonResult;
@@ -179,8 +181,9 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   VideoOptions *pigeonResult = [[VideoOptions alloc] init];
   pigeonResult.enableAudio = GetNullableObjectAtIndex(list, 0);
   NSAssert(pigeonResult.enableAudio != nil, @"");
-  pigeonResult.android = [AndroidVideoOptions nullableFromList:(GetNullableObjectAtIndex(list, 1))];
-  pigeonResult.ios = [CupertinoVideoOptions nullableFromList:(GetNullableObjectAtIndex(list, 2))];
+  pigeonResult.quality = [GetNullableObjectAtIndex(list, 1) integerValue];
+  pigeonResult.android = [AndroidVideoOptions nullableFromList:(GetNullableObjectAtIndex(list, 2))];
+  pigeonResult.ios = [CupertinoVideoOptions nullableFromList:(GetNullableObjectAtIndex(list, 3))];
   return pigeonResult;
 }
 + (nullable VideoOptions *)nullableFromList:(NSArray *)list {
@@ -189,6 +192,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 - (NSArray *)toList {
   return @[
     (self.enableAudio ?: [NSNull null]),
+    @(self.quality),
     (self.android ? [self.android toList] : [NSNull null]),
     (self.ios ? [self.ios toList] : [NSNull null]),
   ];
@@ -197,19 +201,16 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 
 @implementation AndroidVideoOptions
 + (instancetype)makeWithBitrate:(nullable NSNumber *)bitrate
-    quality:(VideoRecordingQuality)quality
     fallbackStrategy:(QualityFallbackStrategy)fallbackStrategy {
   AndroidVideoOptions* pigeonResult = [[AndroidVideoOptions alloc] init];
   pigeonResult.bitrate = bitrate;
-  pigeonResult.quality = quality;
   pigeonResult.fallbackStrategy = fallbackStrategy;
   return pigeonResult;
 }
 + (AndroidVideoOptions *)fromList:(NSArray *)list {
   AndroidVideoOptions *pigeonResult = [[AndroidVideoOptions alloc] init];
   pigeonResult.bitrate = GetNullableObjectAtIndex(list, 0);
-  pigeonResult.quality = [GetNullableObjectAtIndex(list, 1) integerValue];
-  pigeonResult.fallbackStrategy = [GetNullableObjectAtIndex(list, 2) integerValue];
+  pigeonResult.fallbackStrategy = [GetNullableObjectAtIndex(list, 1) integerValue];
   return pigeonResult;
 }
 + (nullable AndroidVideoOptions *)nullableFromList:(NSArray *)list {
@@ -218,7 +219,6 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 - (NSArray *)toList {
   return @[
     (self.bitrate ?: [NSNull null]),
-    @(self.quality),
     @(self.fallbackStrategy),
   ];
 }

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -180,12 +180,16 @@ class PigeonSensor {
 class VideoOptions {
   VideoOptions({
     required this.enableAudio,
+    this.quality,
     this.android,
     this.ios,
   });
 
   /// Enable audio while video recording
   bool enableAudio;
+
+  /// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
+  VideoRecordingQuality? quality;
 
   AndroidVideoOptions? android;
 
@@ -194,6 +198,7 @@ class VideoOptions {
   Object encode() {
     return <Object?>[
       enableAudio,
+      quality?.index,
       android?.encode(),
       ios?.encode(),
     ];
@@ -203,11 +208,14 @@ class VideoOptions {
     result as List<Object?>;
     return VideoOptions(
       enableAudio: result[0]! as bool,
-      android: result[1] != null
-          ? AndroidVideoOptions.decode(result[1]! as List<Object?>)
+      quality: result[1] != null
+          ? VideoRecordingQuality.values[result[1]! as int]
           : null,
-      ios: result[2] != null
-          ? CupertinoVideoOptions.decode(result[2]! as List<Object?>)
+      android: result[2] != null
+          ? AndroidVideoOptions.decode(result[2]! as List<Object?>)
+          : null,
+      ios: result[3] != null
+          ? CupertinoVideoOptions.decode(result[3]! as List<Object?>)
           : null,
     );
   }
@@ -216,7 +224,6 @@ class VideoOptions {
 class AndroidVideoOptions {
   AndroidVideoOptions({
     this.bitrate,
-    this.quality,
     this.fallbackStrategy,
   });
 
@@ -224,15 +231,11 @@ class AndroidVideoOptions {
   /// desired.
   int? bitrate;
 
-  /// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
-  VideoRecordingQuality? quality;
-
   QualityFallbackStrategy? fallbackStrategy;
 
   Object encode() {
     return <Object?>[
       bitrate,
-      quality?.index,
       fallbackStrategy?.index,
     ];
   }
@@ -241,11 +244,8 @@ class AndroidVideoOptions {
     result as List<Object?>;
     return AndroidVideoOptions(
       bitrate: result[0] as int?,
-      quality: result[1] != null
-          ? VideoRecordingQuality.values[result[1]! as int]
-          : null,
-      fallbackStrategy: result[2] != null
-          ? QualityFallbackStrategy.values[result[2]! as int]
+      fallbackStrategy: result[1] != null
+          ? QualityFallbackStrategy.values[result[1]! as int]
           : null,
     );
   }
@@ -494,6 +494,7 @@ class AnalysisImageWrapper {
 
 class _AnalysisImageUtilsCodec extends StandardMessageCodec {
   const _AnalysisImageUtilsCodec();
+
   @override
   void writeValue(WriteBuffer buffer, Object? value) {
     if (value is AnalysisImageWrapper) {
@@ -650,6 +651,7 @@ class AnalysisImageUtils {
 
 class _CameraInterfaceCodec extends StandardMessageCodec {
   const _CameraInterfaceCodec();
+
   @override
   void writeValue(WriteBuffer buffer, Object? value) {
     if (value is AndroidFocusSettings) {

--- a/pigeons/interface.dart
+++ b/pigeons/interface.dart
@@ -64,6 +64,9 @@ class VideoOptions {
   /// Enable audio while video recording
   final bool enableAudio;
 
+  /// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
+  final VideoRecordingQuality? quality;
+
   // TODO if there are properties common to all platform, move them here (iOS, Android and Web)
   final AndroidVideoOptions? android;
   final CupertinoVideoOptions? ios;
@@ -72,6 +75,7 @@ class VideoOptions {
     required this.android,
     required this.ios,
     required this.enableAudio,
+    required this.quality,
   });
 }
 
@@ -80,14 +84,10 @@ class AndroidVideoOptions {
   /// desired.
   final int? bitrate;
 
-  /// The quality of the video recording, defaults to [VideoRecordingQuality.highest].
-  final VideoRecordingQuality? quality;
-
   final QualityFallbackStrategy? fallbackStrategy;
 
   AndroidVideoOptions({
     required this.bitrate,
-    required this.quality,
     required this.fallbackStrategy,
   });
 }


### PR DESCRIPTION
## Description

While CameraAwesome allows to set video recording quality for the Android platform, iOS currently fall behind.

This PR moves the `VideoRecordingQuality` option from `AndroidVideoOptions` to `VideoOptions`. 

The iOS plugin implementation uses this option to configure video output settings and fallback to the preview size if not specified or if the quality is too high for the AV capture session preset.

This should help #211.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.
