### PR TITLE
Remove 'quality' parameter from Example to resolve 'undefined_named_parameter' error

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,6 @@ class CameraPage extends StatelessWidget {
               ),
               android: AndroidVideoOptions(
                 bitrate: 6000000,
-                quality: VideoRecordingQuality.fhd,
                 fallbackStrategy: QualityFallbackStrategy.lower,
               ),
             ),


### PR DESCRIPTION

## Description

In the Example program, I have removed the quality: VideoRecordingQuality.fhd, parameter to address the undefined_named_parameter error.
## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*