### PR TITLE
Updated progress indicator to AwesomeCameraPreview

### DIFF
--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -461,6 +461,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
                     : AwesomeCameraPreview(
                         key: _cameraPreviewKey,
                         previewFit: widget.previewFit,
+                        loadingWidget: widget.progressIndicator,
                         state: snapshot.requireData,
                         padding: widget.previewPadding,
                         alignment: widget.previewAlignment,


### PR DESCRIPTION
## Description

This pull request fixes the issue which the custom progress indicator is not pass down to the camera preview widget.
This results in inconsistent progress indicator loading screen, right before the actual camera preview is opened.

**How to reproduce:**
1. Create a fullscreen black progress indicator widget
2. Set the widget for **progressIndicator** property

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*