### PR TITLE
Safely retrieve list value as double by casting int

### DIFF
--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -1264,6 +1264,14 @@ class CameraInterface {
     }
   }
 
+  double safelyRetrieveAndCastFirstValue(List<Object?> replyList) {
+    if (replyList[0] is int) {
+      return (replyList[0] as int).toDouble();
+    } else {
+      return (replyList[0] as double?)!;
+    }
+  }
+  
   Future<double> getMinZoom() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.CameraInterface.getMinZoom', codec,
@@ -1286,7 +1294,7 @@ class CameraInterface {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (replyList[0] as double?)!;
+      return (safelyRetrieveAndCastFirstValue(replyList))!;
     }
   }
 
@@ -1312,7 +1320,7 @@ class CameraInterface {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (replyList[0] as double?)!;
+      return (safelyRetrieveAndCastFirstValue(replyList))!;
     }
   }
 


### PR DESCRIPTION
## Description

The `AwesomeZoomSelector` is broken on iOS. Casting int to double fixes the issue. See #458 

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*