### PR TITLE
Fixes to Preview and AnalysisImage resolution selection, aspect ratio and convertFromImage

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -190,7 +190,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
         cameraState.apply {
             try {
                 imageAnalysisBuilder = ImageAnalysisBuilder.configure(
-                    aspectRatio ?: AspectRatio.RATIO_4_3,
+                    aspectRatio ?: aspectRatio!!,
                     when (format.uppercase()) {
                         "YUV_420" -> OutputImageFormat.YUV_420_888
                         "NV21" -> OutputImageFormat.NV21

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
@@ -92,7 +92,6 @@ data class CameraXState(
     @SuppressLint("RestrictedApi", "UnsafeOptInUsageError")
     fun updateLifecycle(activity: Activity) {
         previews = mutableListOf()
-        Log.d("KOTLIN", "Aspect ratio: $aspectRatio")
         imageCaptures.clear()
         videoCaptures.clear()
         if (cameraProvider.isMultiCamSupported() && sensors.size > 1) {
@@ -295,20 +294,7 @@ data class CameraXState(
                 useCaseGroup,
             )
             previewCamera!!.cameraControl.enableTorch(flashMode == FlashMode.ALWAYS)
-            useCaseGroup.getUseCases()?.forEach{
-                Log.d("KOTLIN", "Use case ${it.javaClass.kotlin} surface resolution: ${it.attachedSurfaceResolution}")
-            }
             
-        }
-        val characteristics = CameraCharacteristicsCompat.toCameraCharacteristicsCompat(
-            Camera2CameraInfo.extractCameraCharacteristics(previewCamera!!.getCameraInfo()),
-            Camera2CameraInfo.from(previewCamera!!.getCameraInfo()).cameraId
-        )
-        val streamConfigMap = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
-        val resolutions = streamConfigMap?.getOutputSizes(ImageFormat.YUV_420_888)
-        val previewSizesList = previewSizes()
-        resolutions?.forEach{
-            Log.d("KOTLIN", "Preview available size: $it")
         }
     }
 

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/ImageAnalysisBuilder.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/ImageAnalysisBuilder.kt
@@ -54,7 +54,6 @@ class ImageAnalysisBuilder private constructor(
                 AspectRatio.RATIO_4_3 -> 4f / 3
                 else -> 16f / 9
             }
-            Log.d("KOTLIN", "Analysis Aspect Ratio: $aspectRatio ($analysisAspectRatio)")
             val height = widthOrDefault * (1 / analysisAspectRatio)
             val maxFps = if (maxFramesPerSecond == 0.0) null else maxFramesPerSecond
             return ImageAnalysisBuilder(
@@ -71,7 +70,6 @@ class ImageAnalysisBuilder private constructor(
     @SuppressLint("RestrictedApi")
     fun build(): ImageAnalysis {
         countDownLatch.reset()
-        Log.d("KOTLIN", "Building image analysis at target resolution ${width}x${height}")
         val imageAnalysisResolutionSelector = ResolutionSelector.Builder()
             .setAspectRatioStrategy(
                 AspectRatioStrategy(aspectRatio, AspectRatioStrategy.FALLBACK_RULE_AUTO)
@@ -143,7 +141,6 @@ class ImageAnalysisBuilder private constructor(
                 AspectRatio.RATIO_4_3 -> 4f / 3
                 else -> 16f / 9
             }
-        Log.d("KOTLIN", "Analysis Aspect Ratio: $aspectRatio ($analysisAspectRatio)")
         height = (width * (1 / analysisAspectRatio)).toInt()
     }
 

--- a/example/lib/preview_overlay_example.dart
+++ b/example/lib/preview_overlay_example.dart
@@ -48,6 +48,7 @@ class _CameraPageState extends State<CameraPage> {
           aspectRatio: CameraAspectRatios.ratio_16_9,
         ),
         previewFit: CameraPreviewFit.fitWidth,
+        previewAlignment: Alignment.center,
         onMediaTap: (mediaCapture) {
           mediaCapture.captureRequest
               .when(single: (single) => single.file?.open());

--- a/example/lib/widgets/barcode_preview_overlay.dart
+++ b/example/lib/widgets/barcode_preview_overlay.dart
@@ -64,7 +64,7 @@ class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
     // including the clipping that may be needed to respect the current
     // aspectRatio.
     _scanArea = Rect.fromCenter(
-      center: widget.preview.rect.center,
+      center: widget.preview.rect.center + widget.preview.offset,
       // In this example, we want the barcode scan area to be a fraction
       // of the preview that is seen by the user, so we use previewRect
       width: widget.preview.rect.width * 0.7,
@@ -152,6 +152,9 @@ class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
           bottomRightOffset.toOffset(),
           img,
         );
+        debugPrint(
+            'BARCODE $topLeftOffset $bottomRightOffset, $topLeftOff, $bottomRightOff');
+        debugPrint('SCAN AREA ${widget.preview.rect.top}');
 
         _barcodeRect = Rect.fromLTRB(
           topLeftOff.dx,
@@ -163,10 +166,7 @@ class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
         // Approximately detect if the barcode is in the scan area by checking
         // if the center of the barcode is in the scan area.
         if (_scanArea.contains(
-          _barcodeRect!.center.translate(
-            (_screenSize.width - widget.preview.previewSize.width) / 2,
-            (_screenSize.height - widget.preview.previewSize.height) / 2,
-          ),
+          _barcodeRect!.center,
         )) {
           // Note: for a better detection, you should calculate the area of the
           // intersection between the barcode and the scan area and compare it

--- a/example/lib/widgets/barcode_preview_overlay.dart
+++ b/example/lib/widgets/barcode_preview_overlay.dart
@@ -23,7 +23,6 @@ class BarcodePreviewOverlay extends StatefulWidget {
 }
 
 class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
-  late Size _screenSize;
   late Rect _scanArea;
 
   // The barcode that is currently in the scan area (one at a time)
@@ -74,8 +73,6 @@ class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
 
   @override
   Widget build(BuildContext context) {
-    _screenSize = MediaQuery.of(context).size;
-
     return IgnorePointer(
       ignoring: true,
       child: Stack(children: [

--- a/example/lib/widgets/barcode_preview_overlay.dart
+++ b/example/lib/widgets/barcode_preview_overlay.dart
@@ -152,9 +152,6 @@ class _BarcodePreviewOverlayState extends State<BarcodePreviewOverlay> {
           bottomRightOffset.toOffset(),
           img,
         );
-        debugPrint(
-            'BARCODE $topLeftOffset $bottomRightOffset, $topLeftOff, $bottomRightOff');
-        debugPrint('SCAN AREA ${widget.preview.rect.top}');
 
         _barcodeRect = Rect.fromLTRB(
           topLeftOff.dx,

--- a/lib/src/orchestrator/analysis/analysis_to_image.dart
+++ b/lib/src/orchestrator/analysis/analysis_to_image.dart
@@ -41,27 +41,32 @@ class Preview {
   }) {
     num imageDiffX;
     num imageDiffY;
+    num imgToNativeScaleX;
+    num imgToNativeScaleY;
     final shouldflipXY = flipXY ?? img.flipXY();
     if (Platform.isIOS) {
       imageDiffX = img.size.width - img.croppedSize.width;
       imageDiffY = img.size.height - img.croppedSize.height;
+      imgToNativeScaleX = nativePreviewSize.width / img.croppedSize.width;
+      imgToNativeScaleY = nativePreviewSize.height / img.croppedSize.height;
     } else {
       // Width and height are inverted on Android
       imageDiffX = img.size.height - img.croppedSize.width;
       imageDiffY = img.size.width - img.croppedSize.height;
+      imgToNativeScaleX = nativePreviewSize.width / img.croppedSize.width;
+      imgToNativeScaleY = nativePreviewSize.height / img.croppedSize.height;
     }
-    var offset = (Offset(
-              (shouldflipXY ? point.dy : point.dx).toDouble() -
-                  (imageDiffX / 2),
-              (shouldflipXY ? point.dx : point.dy).toDouble() -
-                  (imageDiffY / 2),
-            ) *
-            scale)
-        .translate(
-      // If screenSize is bigger than croppedSize, move the element to half the difference
-      (previewSize.width - (img.croppedSize.width * scale)) / 2,
-      (previewSize.height - (img.croppedSize.height * scale)) / 2,
-    );
+    debugPrint('IMAGE DIFF X: $imageDiffX Y: $imageDiffY');
+    debugPrint('PREVIEW SCALE: $scale $previewSize $nativePreviewSize');
+    debugPrint(
+        'IMAGE TO NATIVE SCALE X: $imgToNativeScaleX, Y: $imgToNativeScaleY');
+    debugPrint('PREVIEW OFFSET: ${this.offset.dx}x${this.offset.dy}');
+    var offset = Offset(
+      (shouldflipXY ? point.dy : point.dx).toDouble() - (imageDiffX / 2),
+      (shouldflipXY ? point.dx : point.dy).toDouble() - (imageDiffY / 2),
+    )
+        .scale(imgToNativeScaleX * scale, imgToNativeScaleY * scale)
+        .translate(this.offset.dx, this.offset.dy);
     return offset;
   }
 

--- a/lib/src/orchestrator/analysis/analysis_to_image.dart
+++ b/lib/src/orchestrator/analysis/analysis_to_image.dart
@@ -39,26 +39,26 @@ class Preview {
     AnalysisImage img, {
     bool? flipXY,
   }) {
-    num imageDiffX;
-    num imageDiffY;
+    num imageStretchX;
+    num imageStretchY;
     num imgToNativeScaleX;
     num imgToNativeScaleY;
     final shouldflipXY = flipXY ?? img.flipXY();
     if (Platform.isIOS) {
-      imageDiffX = img.size.width - img.croppedSize.width;
-      imageDiffY = img.size.height - img.croppedSize.height;
+      imageStretchX = img.size.width / img.croppedSize.width;
+      imageStretchY = img.size.height / img.croppedSize.height;
       imgToNativeScaleX = nativePreviewSize.width / img.croppedSize.width;
       imgToNativeScaleY = nativePreviewSize.height / img.croppedSize.height;
     } else {
       // Width and height are inverted on Android
-      imageDiffX = img.size.height - img.croppedSize.width;
-      imageDiffY = img.size.width - img.croppedSize.height;
+      imageStretchX = img.size.height / img.croppedSize.width;
+      imageStretchY = img.size.width / img.croppedSize.height;
       imgToNativeScaleX = nativePreviewSize.width / img.croppedSize.width;
       imgToNativeScaleY = nativePreviewSize.height / img.croppedSize.height;
     }
     var offset = Offset(
-      (shouldflipXY ? point.dy : point.dx).toDouble() - (imageDiffX / 2),
-      (shouldflipXY ? point.dx : point.dy).toDouble() - (imageDiffY / 2),
+      (shouldflipXY ? point.dy : point.dx).toDouble() / imageStretchX,
+      (shouldflipXY ? point.dx : point.dy).toDouble() / imageStretchY,
     )
         .scale(imgToNativeScaleX * scale, imgToNativeScaleY * scale)
         .translate(this.offset.dx, this.offset.dy);

--- a/lib/src/orchestrator/analysis/analysis_to_image.dart
+++ b/lib/src/orchestrator/analysis/analysis_to_image.dart
@@ -56,11 +56,6 @@ class Preview {
       imgToNativeScaleX = nativePreviewSize.width / img.croppedSize.width;
       imgToNativeScaleY = nativePreviewSize.height / img.croppedSize.height;
     }
-    debugPrint('IMAGE DIFF X: $imageDiffX Y: $imageDiffY');
-    debugPrint('PREVIEW SCALE: $scale $previewSize $nativePreviewSize');
-    debugPrint(
-        'IMAGE TO NATIVE SCALE X: $imgToNativeScaleX, Y: $imgToNativeScaleY');
-    debugPrint('PREVIEW OFFSET: ${this.offset.dx}x${this.offset.dy}');
     var offset = Offset(
       (shouldflipXY ? point.dy : point.dx).toDouble() - (imageDiffX / 2),
       (shouldflipXY ? point.dx : point.dy).toDouble() - (imageDiffY / 2),

--- a/lib/src/widgets/preview/awesome_preview_fit.dart
+++ b/lib/src/widgets/preview/awesome_preview_fit.dart
@@ -45,6 +45,7 @@ class _AnimatedPreviewFitState extends State<AnimatedPreviewFit> {
       previewFit: widget.previewFit,
       previewSize: widget.previewSize,
       constraints: widget.constraints,
+      previewAlignment: widget.alignment,
     );
     sizeCalculator!.compute();
     maxSize = sizeCalculator!.maxSize;
@@ -66,11 +67,13 @@ class _AnimatedPreviewFitState extends State<AnimatedPreviewFit> {
         previewFit: oldWidget.previewFit,
         previewSize: oldWidget.previewSize,
         constraints: oldWidget.constraints,
+        previewAlignment: oldWidget.alignment,
       );
       sizeCalculator = PreviewSizeCalculator(
         previewFit: widget.previewFit,
         previewSize: widget.previewSize,
         constraints: widget.constraints,
+        previewAlignment: widget.alignment,
       );
       oldsizeCalculator.compute();
       sizeCalculator!.compute();
@@ -116,7 +119,7 @@ class _AnimatedPreviewFitState extends State<AnimatedPreviewFit> {
           previewFit: widget.previewFit,
           previewSize: widget.previewSize,
           scale: ratio,
-          maxSize: maxSize!,
+          maxSize: currentSize,
           child: child!,
         );
       },
@@ -163,7 +166,7 @@ class PreviewFitWidget extends StatelessWidget {
           scaleEnabled: false,
           constrained: false,
           panEnabled: false,
-          alignment: FractionalOffset.topLeft,
+          alignment: Alignment.topLeft,
           clipBehavior: Clip.antiAlias,
           child: Align(
             alignment: Alignment.topLeft,
@@ -185,6 +188,7 @@ class PreviewSizeCalculator {
   final CameraPreviewFit previewFit;
   final PreviewSize previewSize;
   final BoxConstraints constraints;
+  final Alignment previewAlignment;
 
   Size? _maxSize;
   double? _zoom;
@@ -194,6 +198,7 @@ class PreviewSizeCalculator {
     required this.previewFit,
     required this.previewSize,
     required this.constraints,
+    required this.previewAlignment,
   });
 
   void compute() {
@@ -222,6 +227,12 @@ class PreviewSizeCalculator {
     return _offset!;
   }
 
+  Offset _computeOffset(num wDiff, num hDiff) {
+    final wMult = (previewAlignment.x + 1) / 2;
+    final hMult = (previewAlignment.y + 1) / 2;
+    return Offset(wDiff * wMult, hDiff * hMult);
+  }
+
   Size _computeMaxSize() {
     var nativePreviewSize = previewSize.toSize();
     Size maxSize;
@@ -230,38 +241,40 @@ class PreviewSizeCalculator {
 
     final nativeHeightProjection = constraints.maxHeight * 1 / zoom;
     final hDiff = nativePreviewSize.height - nativeHeightProjection;
+    debugPrint(
+        'COMPUTE PREVIEW SIZE: $nativeWidthProjection $nativeHeightProjection $nativePreviewSize, ZOOM: $zoom');
 
     switch (previewFit) {
       case CameraPreviewFit.fitWidth:
         maxSize = Size(constraints.maxWidth, nativePreviewSize.height * zoom);
-        _offset = Offset(0, constraints.maxHeight - maxSize.height);
+        _offset = _computeOffset(0, constraints.maxHeight - maxSize.height);
         break;
       case CameraPreviewFit.fitHeight:
         maxSize = Size(nativePreviewSize.width * zoom, constraints.maxHeight);
-        _offset = Offset(constraints.maxWidth - maxSize.width, 0);
+        _offset = _computeOffset(constraints.maxWidth - maxSize.width, 0);
         break;
       case CameraPreviewFit.cover:
         maxSize = Size(constraints.maxWidth, constraints.maxHeight);
 
         if (constraints.maxWidth / constraints.maxHeight >
             previewSize.width / previewSize.height) {
-          _offset = Offset((hDiff * zoom) * 2, 0);
+          _offset = _computeOffset((hDiff * zoom) * 2, 0);
           // _offset = Offset(0, constraints.maxHeight - maxSize.height);
         } else {
-          _offset = Offset(0, (wDiff * zoom));
+          _offset = _computeOffset(0, (wDiff * zoom));
           // _offset = Offset(constraints.maxWidth - maxSize.width, 0);
         }
         break;
       case CameraPreviewFit.contain:
         maxSize = Size(
             nativePreviewSize.width * zoom, nativePreviewSize.height * zoom);
-        _offset = Offset(
+        _offset = _computeOffset(
           constraints.maxWidth - maxSize.width,
           constraints.maxHeight - maxSize.height,
         );
         break;
     }
-
+    debugPrint('MAX PREVIEW SIZE $maxSize $_offset');
     return maxSize;
   }
 
@@ -308,7 +321,8 @@ class PreviewSizeCalculator {
           runtimeType == other.runtimeType &&
           previewFit == other.previewFit &&
           constraints == other.constraints &&
-          previewSize == other.previewSize;
+          previewSize == other.previewSize &&
+          previewAlignment == other.previewAlignment;
 
   @override
   int get hashCode => previewSize.hashCode ^ previewSize.hashCode;

--- a/lib/src/widgets/preview/awesome_preview_fit.dart
+++ b/lib/src/widgets/preview/awesome_preview_fit.dart
@@ -241,8 +241,6 @@ class PreviewSizeCalculator {
 
     final nativeHeightProjection = constraints.maxHeight * 1 / zoom;
     final hDiff = nativePreviewSize.height - nativeHeightProjection;
-    debugPrint(
-        'COMPUTE PREVIEW SIZE: $nativeWidthProjection $nativeHeightProjection $nativePreviewSize, ZOOM: $zoom');
 
     switch (previewFit) {
       case CameraPreviewFit.fitWidth:
@@ -274,7 +272,6 @@ class PreviewSizeCalculator {
         );
         break;
     }
-    debugPrint('MAX PREVIEW SIZE $maxSize $_offset');
     return maxSize;
   }
 


### PR DESCRIPTION
## Description

- Updated resolution selection in CameraX from the deprecated setTargetAspectRatio/setTargetResolution to setResolutionSelector
   - This fixes a bug where the incorrect resolution for ImageAnalysis would be selected because setTargetResolution expected a flipped X/Y input.
   - ImageAnalysis now picks a resolution matching the aspect ratio of the preview if possible
   - TODO: Since 1:1 aspect ratio is not directly supported by CameraX, a ResolutionFilter is needed to force a 1:1 aspect ratio when selected.
- Fixed previewAlignment not working correctly as well as AnimatedPreviewFit not animating correctly on aspect ratio changes
   - Preview.offset is now calculated as offset coordinates of the preview on screen, taking the alignment into account, which helps calculate Preview.convertToImage correctly
- Fixed Preview.convertToImage function now correctly converts point coordinates from AnalysisImage to Preview
- preview_overlay_example and ai_analysis_faces now work correctly on Android with the right positioning of the overlay elements

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*