### PR TITLE
Android crash fix: The result should be dispatched on main thread

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraPermissions.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraPermissions.kt
@@ -124,7 +124,7 @@ class CameraPermissions : EventChannel.StreamHandler, RequestPermissionsResultLi
             callback(permissionsGranted)
         } else {
             // Request the not granted permissions
-            CoroutineScope(Dispatchers.IO).launch {
+            CoroutineScope(Dispatchers.Main).launch {
                 requestPermissions(activity, permissionsToAsk, PERMISSIONS_MULTIPLE_REQUEST) {
                     callback(permissionsGranted.apply { addAll(it) })
                 }


### PR DESCRIPTION
## Description

*What your Pull Request change ?*

After implementing the camera plugin, android app is crashing with the message:
`After requesting not granted permissions, the result should be dispatched on main thread`. 


## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*