### PR TITLE
Android - Rgba8888 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ test/out/
 test_lab.sh
 firebase_key.txt
 google-services.json
+
+android/gradlew
+android/gradlew.bat
+android/gradle/wrapper/gradle-wrapper.jar

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Wed Nov 16 21:50:57 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -195,6 +195,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
                         "YUV_420" -> OutputImageFormat.YUV_420_888
                         "NV21" -> OutputImageFormat.NV21
                         "JPEG" -> OutputImageFormat.JPEG
+                        "BGRA8888" -> OutputImageFormat.RGBA_8888
                         else -> OutputImageFormat.NV21
                     },
                     executor(activity!!), width,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.1.0"
   carousel_slider:
     dependency: transitive
     description:
@@ -76,10 +76,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   colorfilter_generator:
     dependency: transitive
     description:
@@ -306,18 +306,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -474,15 +474,15 @@ packages:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -503,10 +503,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -519,10 +519,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -543,10 +543,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -607,10 +607,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -623,10 +623,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   google_mlkit_text_recognition: ^0.11.0
   image: ^4.1.3
   meta: ^1.10.0
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
   video_player: ^2.8.1
 
 dev_dependencies:

--- a/lib/src/orchestrator/models/analysis/analysis_config.dart
+++ b/lib/src/orchestrator/models/analysis/analysis_config.dart
@@ -57,6 +57,13 @@ class AndroidAnalysisOptions {
           outputFormat: InputAnalysisImageFormat.yuv_420,
         );
 
+  const AndroidAnalysisOptions.bgra8888({
+    required int width,
+  }) : this._(
+          width: width,
+          outputFormat: InputAnalysisImageFormat.bgra8888,
+        );
+
   const AndroidAnalysisOptions.jpeg({
     required int width,
   }) : this._(width: width, outputFormat: InputAnalysisImageFormat.jpeg);

--- a/lib/src/orchestrator/models/analysis/input_analysis.dart
+++ b/lib/src/orchestrator/models/analysis/input_analysis.dart
@@ -18,6 +18,9 @@ InputAnalysisImageFormat inputAnalysisImageFormatParser(String value) {
       return InputAnalysisImageFormat.jpeg;
     case 'nv21': // android.graphics.ImageFormat.nv21
       return InputAnalysisImageFormat.nv21;
+    case 'rgba_8888':
+      return InputAnalysisImageFormat.bgra8888;
+    
   }
   return InputAnalysisImageFormat.unknown;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   archive:
     dependency: transitive
     description:
@@ -106,10 +106,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   colorfilter_generator:
     dependency: "direct main"
     description:
@@ -220,18 +220,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -404,7 +404,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -417,10 +417,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -433,10 +433,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -473,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Easiest Flutter camera Plugin with builtin UI. Supporting capturing images,
   streaming images, video recording, switch sensors, autofocus, flash, filters... on
   Android and iOS.
-version: 2.1.0
+version: 2.2.0
 homepage: https://Apparence.io
 repository: https://github.com/Apparence-io/camera_awesome
 


### PR DESCRIPTION
## Description

This adds support for RGBA_8888 format as CameraX supports this. Ref https://github.com/Apparence-io/CamerAwesome/issues/550

So it solves https://github.com/Apparence-io/CamerAwesome/issues/550

* feat: support rgba8888 output

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

This should not be a breaking change: https://github.com/vongohren/CamerAwesome/pull/1/files#diff-2be105d4e5b13f6f54a34dce7bb62ef5a3a7bcb2f64587e662af5d0306bc57f8R65, as it falls back to the default option

## Analyze
I ran flutter analyze and it outputed files I have not touched so I decided to ignore them. Here is current output

```
Analyzing CamerAwesome...                                               

   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/ai_analysis_barcode.dart:131:36 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_awesome_ui.dart:37:53 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_awesome_ui.dart:39:42 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_awesome_ui.dart:51:49 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_theme.dart:38:59 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_theme.dart:40:48 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/custom_theme.dart:52:61 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          example/lib/multi_camera.dart:175:49 • deprecated_member_use
   info • 'whereNotNull' is deprecated and shouldn't be used. Use .nonNulls instead •
          lib/src/orchestrator/states/camera_state.dart:83:51 • deprecated_member_use
   info • 'whereNotNull' is deprecated and shouldn't be used. Use .nonNulls instead •
          lib/src/orchestrator/states/camera_state.dart:127:12 • deprecated_member_use
   info • 'whereNotNull' is deprecated and shouldn't be used. Use .nonNulls instead •
          lib/src/orchestrator/states/photo_camera_state.dart:75:52 • deprecated_member_use
   info • 'whereNotNull' is deprecated and shouldn't be used. Use .nonNulls instead •
          lib/src/orchestrator/states/video_camera_state.dart:38:52 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          lib/src/widgets/awesome_sensor_type_selector.dart:74:32 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          lib/src/widgets/awesome_sensor_type_selector.dart:144:33 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          lib/src/widgets/buttons/awesome_capture_button.dart:113:36 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          lib/src/widgets/buttons/awesome_capture_button.dart:138:36 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss •
          lib/src/widgets/preview/picture_in_picutre_config.dart:41:45 • deprecated_member_use
          
```