### PR TITLE
Fix: conflict name between Preview from cameraawesome and a new class preview from flutter

### DIFF
--- a/example/lib/ai_analysis_faces.dart
+++ b/example/lib/ai_analysis_faces.dart
@@ -40,7 +40,7 @@ class CameraPage extends StatefulWidget {
 
 class _CameraPageState extends State<CameraPage> {
   final _faceDetectionController = BehaviorSubject<FaceDetectionModel>();
-  Preview? _preview;
+  AnalysisPreview? _preview;
 
   final options = FaceDetectorOptions(
     enableContours: true,
@@ -111,7 +111,7 @@ class _CameraPageState extends State<CameraPage> {
 class _MyPreviewDecoratorWidget extends StatelessWidget {
   final CameraState cameraState;
   final Stream<FaceDetectionModel> faceDetectionStream;
-  final Preview preview;
+  final AnalysisPreview preview;
 
   const _MyPreviewDecoratorWidget({
     required this.cameraState,
@@ -155,7 +155,7 @@ class _MyPreviewDecoratorWidget extends StatelessWidget {
 class FaceDetectorPainter extends CustomPainter {
   final FaceDetectionModel model;
   final CanvasTransformation? canvasTransformation;
-  final Preview? preview;
+  final AnalysisPreview? preview;
 
   FaceDetectorPainter({
     required this.model,

--- a/example/lib/widgets/barcode_preview_overlay.dart
+++ b/example/lib/widgets/barcode_preview_overlay.dart
@@ -7,7 +7,7 @@ class BarcodePreviewOverlay extends StatefulWidget {
   final List<Barcode> barcodes;
   final AnalysisImage? analysisImage;
   final bool isBackCamera;
-  final Preview preview;
+  final AnalysisPreview preview;
 
   const BarcodePreviewOverlay({
     super.key,

--- a/lib/src/orchestrator/analysis/analysis_to_image.dart
+++ b/lib/src/orchestrator/analysis/analysis_to_image.dart
@@ -3,14 +3,14 @@ import 'dart:io';
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:flutter/material.dart';
 
-class Preview {
+class AnalysisPreview {
   final Size nativePreviewSize;
   final Size previewSize;
   final Offset offset;
   final double scale;
   final Sensor? sensor;
 
-  Preview({
+  AnalysisPreview({
     required this.nativePreviewSize,
     required this.previewSize,
     required this.offset,
@@ -18,7 +18,7 @@ class Preview {
     required this.sensor,
   });
 
-  factory Preview.hidden() => Preview(
+  factory AnalysisPreview.hidden() => AnalysisPreview(
         nativePreviewSize: Size.zero,
         previewSize: Size.zero,
         offset: Offset.zero,

--- a/lib/src/orchestrator/models/analysis/analysis_image.dart
+++ b/lib/src/orchestrator/models/analysis/analysis_image.dart
@@ -88,7 +88,7 @@ abstract class AnalysisImage {
   // Symmetry for Android since native image analysis is not mirrored but preview is
   // It also handles device rotation
   CanvasTransformation? getCanvasTransformation(
-    Preview preview,
+    AnalysisPreview preview,
   ) {
     if (!Platform.isAndroid) {
       return null;

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -25,7 +25,7 @@ typedef CameraLayoutBuilder = Widget Function(
   /// relative to the preview (inside or outside for instance)
   //Rect previewRect,
 
-  Preview preview,
+  AnalysisPreview preview,
 );
 
 /// Callback when a video or photo has been saved and user click on thumbnail
@@ -438,7 +438,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
                 child: !widget.showPreview
                     ? widget.builder(
                         snapshot.requireData,
-                        Preview.hidden(),
+                        AnalysisPreview.hidden(),
                       )
                     : AwesomeCameraPreview(
                         key: _cameraPreviewKey,

--- a/lib/src/widgets/preview/awesome_camera_preview.dart
+++ b/lib/src/widgets/preview/awesome_camera_preview.dart
@@ -60,7 +60,7 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
   StreamSubscription? _aspectRatioSubscription;
   CameraAspectRatios? _aspectRatio;
   double? _aspectRatioValue;
-  Preview? _preview;
+  AnalysisPreview? _preview;
 
   // TODO: fetch this value from the native side
   final int kMaximumSupportedFloatingPreview = 3;

--- a/lib/src/widgets/preview/awesome_preview_fit.dart
+++ b/lib/src/widgets/preview/awesome_preview_fit.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 final previewWidgetKey = GlobalKey();
 
-typedef OnPreviewCalculated = void Function(Preview preview);
+typedef OnPreviewCalculated = void Function(AnalysisPreview preview);
 
 class AnimatedPreviewFit extends StatefulWidget {
   final Alignment alignment;
@@ -85,7 +85,7 @@ class _AnimatedPreviewFitState extends State<AnimatedPreviewFit> {
   void _handPreviewCalculated() {
     if (widget.onPreviewCalculated != null) {
       widget.onPreviewCalculated!(
-        Preview(
+        AnalysisPreview(
           nativePreviewSize: widget.previewSize.toSize(),
           previewSize: sizeCalculator!.maxSize,
           offset: sizeCalculator!.offset,


### PR DESCRIPTION
## Description

This PR resolves the name conflict with the newly introduced Preview class in Flutter (beta 3.32.0-0.3.pre) by renaming camerawesome’s internal Preview class to AnalysisPreview. Fixes #571 

I initially tried using hide Preview in imports for example `import 'package:flutter/material.dart' hide Preview;' to work around the issue, but it led to additional conflicts when exporting components from the library, and could cause potential problems in the future. Renaming the class to AnalysisPreview seemed like a more sustainable solution.

However, this change introduces a breaking change: any users who have imported the original Preview class will need to update their imports to reflect the new class name (AnalysisPreview), which could potentially break existing code.

While this may not be the perfect name, maybe AwesomePreview sounds better. The class was located in example/lib/ai_analysis_faces.dart, and renaming it seemed like a reasonable approach to avoid the conflict and ensure clearer separation between Flutter framework classes and library internals. Feedback on the naming choice is welcome!

This change eliminates the need for hide Preview in imports.

Note: I recommend holding off on merging it until the current Flutter beta is promoted to stable. This is because the conflict involves the new Preview class introduced in the Flutter framework (package:flutter/src/widgets/widget_preview.dart), which is not yet available in the stable channel.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [x] 🛠 My feature contain breaking change.

Any users who have imported the original Preview class will need to update their imports to reflect the new class name (AnalysisPreview), which could potentially break existing code.


Related #571