### PR TITLE
Modify getJpegOrientation to fallback orientation when motion sensor is disabled or returns UIDeviceOrientationUnknown

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/Controllers/Picture/CameraPictureController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Picture/CameraPictureController.m
@@ -185,21 +185,66 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   return cropped;
 }
 
+// Helper #1: map a “known” UIDeviceOrientation → UIImageOrientation
+- (UIImageOrientation)imageOrientationFromDeviceOrientation:(UIDeviceOrientation)devOrient {
+    switch (devOrient) {
+        case UIDeviceOrientationPortrait:
+            return (self.sensorPosition == PigeonSensorPositionFront && _mirrorFrontCamera)
+                ? UIImageOrientationLeftMirrored
+                : UIImageOrientationRight;
+        case UIDeviceOrientationPortraitUpsideDown:
+            return UIImageOrientationLeft;
+        case UIDeviceOrientationLandscapeLeft:
+            return (self.sensorPosition == PigeonSensorPositionBack)
+                ? UIImageOrientationDown
+                : UIImageOrientationUp;
+        case UIDeviceOrientationLandscapeRight:
+            return (self.sensorPosition == PigeonSensorPositionBack)
+                ? UIImageOrientationUp
+                : UIImageOrientationDown;
+        default:
+            return UIImageOrientationUp;
+    }
+}
+
+// Helper #2: map a UIInterfaceOrientation → UIImageOrientation
+- (UIImageOrientation)imageOrientationFromInterfaceOrientation:(UIInterfaceOrientation)uiOrient {
+    switch (uiOrient) {
+        case UIInterfaceOrientationPortrait:
+            return (self.sensorPosition == PigeonSensorPositionFront && _mirrorFrontCamera)
+                ? UIImageOrientationLeftMirrored
+                : UIImageOrientationRight;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return UIImageOrientationLeft;
+        case UIInterfaceOrientationLandscapeLeft:
+            return (self.sensorPosition == PigeonSensorPositionBack)
+                ? UIImageOrientationDown
+                : UIImageOrientationUp;
+        case UIInterfaceOrientationLandscapeRight:
+            return (self.sensorPosition == PigeonSensorPositionBack)
+                ? UIImageOrientationUp
+                : UIImageOrientationDown;
+        default:
+            return UIImageOrientationUp;
+    }
+}
+
 - (UIImageOrientation)getJpegOrientation {
-  switch (_orientation) {
-    case UIDeviceOrientationPortrait:
-      if (self.sensorPosition == PigeonSensorPositionFront && _mirrorFrontCamera) {
-        return UIImageOrientationLeftMirrored;
-      } else {
-        return UIImageOrientationRight;
-      }
-    case UIDeviceOrientationLandscapeRight:
-      return (self.sensorPosition == PigeonSensorPositionBack) ? UIImageOrientationUp : UIImageOrientationDown;
-    case UIDeviceOrientationLandscapeLeft:
-      return (self.sensorPosition == PigeonSensorPositionBack) ? UIImageOrientationDown : UIImageOrientationUp;
-    default:
-      return UIImageOrientationLeft;
-  }
+    UIDeviceOrientation devOrient = _orientation;
+    // Check if _orientation is one of the ones we handle directly
+    if (devOrient != UIDeviceOrientationUnknown) {
+        return [self imageOrientationFromDeviceOrientation:devOrient];
+    }
+
+    // Fallback: pull the UI orientation
+    UIInterfaceOrientation uiOrient;
+    if (@available(iOS 13.0, *)) {
+        uiOrient = UIApplication.sharedApplication
+                        .windows.firstObject.windowScene.interfaceOrientation;
+    } else {
+        uiOrient = UIApplication.sharedApplication.statusBarOrientation;
+    }
+    return [self imageOrientationFromInterfaceOrientation:uiOrient];
 }
 
 @end


### PR DESCRIPTION

## Description

This pull request refactors the JPEG orientation lookup by:

- Extracting two helpers:
    - `imageOrientationFromDeviceOrientation`: for mapping a known `UIDeviceOrientation → UIImageOrientation`
    - `imageOrientationFromInterfaceOrientation`: for mapping a `UIInterfaceOrientation → UIImageOrientation`

- Modifying `getJpegOrientation` to fall back to the current interface orientation when the motion sensor is disabled or returns `UIDeviceOrientationUnknown`.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x ] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x ] 🤝 I match the actual coding style.
- [x ] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*No breaking changes: existing behavior is preserved except better fallback for unknown orientations.*