### PR TITLE
Fix(ios) setRecordingAudioMode not competed

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -586,6 +586,7 @@
   }
   
   [_captureSession commitConfiguration];
+  completion(@(YES), nil);
 }
 
 # pragma mark - Audio


### PR DESCRIPTION
## Description

CamerawesomePlugin.setAudioMode not competed

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*