### PR TITLE
fix(ios): Set videoIsDisconnected instead of audioIsDisconnected during camera switch

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -305,8 +305,14 @@
       }
     }
   }
-  [_videoController setAudioIsDisconnected:YES];
-  
+  // FIX: Changed from setAudioIsDisconnected to setVideoIsDisconnected.
+  // VIDEO is what's being switched (brief gap while new camera initializes),
+  // not audio. Setting the wrong flag caused audio timestamps to be offset
+  // while video timestamps weren't compensated for the gap, causing desync.
+  // The videoIsDisconnected flag triggers proper timestamp gap compensation
+  // in VideoController.m's captureOutput method.
+  [_videoController setVideoIsDisconnected:YES];
+
   [_captureSession removeOutput:_capturePhotoOutput];
   [_captureSession removeConnection:_captureConnection];
   


### PR DESCRIPTION
## Problem

When switching cameras during video recording on iOS, the code incorrectly sets `audioIsDisconnected = YES` instead of `videoIsDisconnected = YES`. This causes audio/video desynchronization because:

1. During a camera switch, the **video** stream is briefly interrupted (gap while new camera initializes)
2. The **audio** stream continues uninterrupted
3. Setting `audioIsDisconnected` causes audio timestamps to be offset
4. Video timestamps are NOT compensated for the gap
5. Result: audio and video drift out of sync after camera switch

## Solution

Change `setAudioIsDisconnected:YES` to `setVideoIsDisconnected:YES` in `SingleCameraPreview.m` during camera switching. The `videoIsDisconnected` flag triggers proper timestamp gap compensation in `VideoController.m`'s `captureOutput` method.

## Testing

1. Start video recording with front camera
2. Switch to back camera mid-recording while speaking
3. Switch back to front camera
4. Stop recording and play back
5. Verify audio and video remain synchronized throughout

## Files Changed
- `ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m`

## Checklist
Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes ([x]).

- [x]  📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x]  🤝 I match the actual coding style.
- [x]  ✅ I ran flutter analyze without any issues.