### PR TITLE
fix(ios): Re-apply custom FPS settings when switching cameras during recording

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -315,7 +315,11 @@
   
   // Init the camera preview with the selected sensor
   [self initCameraPreview:sensor.position];
-  
+
+  // Update VideoController with new capture device to re-apply custom FPS if recording
+  // This fixes audio/video desync when switching cameras during recording with custom FPS
+  [_videoController updateCaptureDevice:_captureDevice];
+
   [self setBestPreviewQuality];
   
   [_captureSession commitConfiguration];

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Video/VideoController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Video/VideoController.m
@@ -417,4 +417,16 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   _audioIsDisconnected = audioIsDisconnected;
 }
 
+/// Update capture device reference and re-apply FPS if recording with custom FPS
+/// This should be called after switching cameras during recording to ensure
+/// the new camera device uses the same FPS as the original recording settings.
+- (void)updateCaptureDevice:(AVCaptureDevice *)device {
+  _captureDevice = device;
+
+  // Re-apply custom FPS if recording is in progress and custom FPS was specified
+  if (_isRecording && _options && _options.fps != nil && _options.fps.intValue > 0) {
+    [self adjustCameraFPS:_options.fps];
+  }
+}
+
 @end

--- a/ios/camerawesome/Sources/camerawesome/include/VideoController.h
+++ b/ios/camerawesome/Sources/camerawesome/include/VideoController.h
@@ -48,6 +48,7 @@ typedef void(^OnVideoWriterSetup)(void);
 - (void)setVideoIsDisconnected:(bool)videoIsDisconnected;
 - (void)setAudioIsDisconnected:(bool)audioIsDisconnected;
 - (void)setPreviewSize:(CGSize)previewSize;
+- (void)updateCaptureDevice:(AVCaptureDevice *)device;
 
 @end
 


### PR DESCRIPTION
## Problem

When using custom FPS settings in `CupertinoVideoOptions` (e.g., `fps: 24`) and switching cameras during recording:

1. Recording starts with Camera A at custom FPS (e.g., 24 FPS)
2. User switches to Camera B mid-recording
3. Camera B initializes with its **native FPS** (e.g., 30 or 60 FPS), ignoring the custom setting
4. The video now has mixed frame rates, causing audio/video desynchronization
5. Audio recorded at constant rate no longer aligns with variable-rate video frames

## Solution

Add `updateCaptureDevice:` method to `VideoController` that:
1. Updates the capture device reference when camera switches
2. Checks if recording is active and custom FPS was specified
3. Re-applies the custom FPS to the new camera device

## Testing

1. Configure `CupertinoVideoOptions` with custom `fps: 24`
2. Start recording and speak continuously ("1, 2, 3...")
3. Switch cameras mid-recording
4. Continue speaking and switch cameras again
5. Stop recording and verify audio/video remain in sync

## Files Changed
- `ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m`
- `ios/camerawesome/Sources/camerawesome/Controllers/Video/VideoController.m`
- `ios/camerawesome/Sources/camerawesome/include/VideoController.h`

## Checklist
Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes ([x]).

- [x]  📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x]  🤝 I match the actual coding style.
- [x]  ✅ I ran flutter analyze without any issues.