### PR TITLE
Revert: fix(ios): Set videoIsDisconnected instead of audioIsDisconnected during camera switch

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -333,14 +333,8 @@
       }
     }
   }
-  // FIX: Changed from setAudioIsDisconnected to setVideoIsDisconnected.
-  // VIDEO is what's being switched (brief gap while new camera initializes),
-  // not audio. Setting the wrong flag caused audio timestamps to be offset
-  // while video timestamps weren't compensated for the gap, causing desync.
-  // The videoIsDisconnected flag triggers proper timestamp gap compensation
-  // in VideoController.m's captureOutput method.
-  [_videoController setVideoIsDisconnected:YES];
-
+  [_videoController setAudioIsDisconnected:YES];
+  
   [_captureSession removeOutput:_capturePhotoOutput];
   [_captureSession removeConnection:_captureConnection];
   


### PR DESCRIPTION
## Reverts PR #629

This reverts the change from `setAudioIsDisconnected:YES` to `setVideoIsDisconnected:YES` during camera switching in `SingleCameraPreview.m`.

## Problem

PR #629 introduced an intermittent bug where recorded videos would have **no audio**. After the change, the audio stream doesn't reliably warm up and attach when only the video disconnection flag is set during camera switching. This causes recordings to intermittently lose their audio track entirely.

Reverting to the original `setAudioIsDisconnected:YES` in our app's fork of the package resolved the issue.

## What Changed

- `[_videoController setVideoIsDisconnected:YES]` → `[_videoController setAudioIsDisconnected:YES]` (restoring original behavior)
- Removed comments added in PR #629

## Files Changed
- `ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m`

## Testing

1. Start video recording
2. Record multiple short videos (~10-15 seconds each)
3. Verify all recordings have audio on playback
4. Switch cameras during recording and verify audio is present
5. Repeat steps 2-4 multiple times to confirm no intermittent audio loss

## Checklist
Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes ([x]).

- [x]  📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x]  🤝 I match the actual coding style.
- [x]  ✅ I ran flutter analyze without any issues.