### PR TITLE
Revert "fix(ios): Fix audio/video desync on first recording after app launch"

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -276,37 +276,9 @@
 
 /// Start camera preview
 - (void)start {
-  // Create semaphore to wait for first frame
-  dispatch_semaphore_t firstFrameSemaphore = dispatch_semaphore_create(0);
-
-  // Set up one-shot callback to signal when first frame is received
-  self.onFirstFrameReceived = ^{
-    dispatch_semaphore_signal(firstFrameSemaphore);
-  };
-
-  // Start the capture session
   dispatch_async(_dispatchQueue, ^{
     [self->_captureSession startRunning];
-
-    // Pre-warm audio input/output to avoid cold-start sync issues on first recording
-    // Without this, first recording has audio delay because audio is set up on-demand
-    if (self->_videoController.isAudioEnabled && !self->_videoController.isAudioSetup) {
-      [self setUpCaptureSessionForAudioError:^(NSError *error) {
-        // Audio setup failed, but we can continue - it will be retried when recording starts
-        NSLog(@"[CamerAwesome] Audio pre-warm failed: %@", error.localizedDescription);
-      }];
-    }
   });
-
-  // Wait for first frame with timeout (2 seconds max)
-  // This ensures camera is actually delivering frames before returning
-  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC);
-  long result = dispatch_semaphore_wait(firstFrameSemaphore, timeout);
-  if (result != 0) {
-    NSLog(@"[CamerAwesome] Warning: Timeout waiting for first camera frame");
-    // Clear the callback since we're giving up waiting
-    self.onFirstFrameReceived = nil;
-  }
 }
 
 /// Stop camera preview
@@ -662,13 +634,6 @@
     [self.previewTexture updateBuffer:sampleBuffer];
     if (_onPreviewFrameAvailable) {
       _onPreviewFrameAvailable();
-    }
-
-    // Signal first frame received (one-shot callback)
-    if (_onFirstFrameReceived) {
-      void (^callback)(void) = _onFirstFrameReceived;
-      _onFirstFrameReceived = nil; // Clear to ensure one-shot behavior
-      callback();
     }
 
     // Send to image stream controller if enabled

--- a/ios/camerawesome/Sources/camerawesome/include/SingleCameraPreview.h
+++ b/ios/camerawesome/Sources/camerawesome/include/SingleCameraPreview.h
@@ -65,7 +65,6 @@ AVCaptureAudioDataOutputSampleBufferDelegate>
 @property(readonly, nonatomic) PhysicalButtonController *physicalButtonController;
 @property(readonly, copy) void (^completion)(NSNumber * _Nullable, FlutterError * _Nullable);
 @property(nonatomic, copy) void (^onPreviewFrameAvailable)(void);
-@property(nonatomic, copy) void (^onFirstFrameReceived)(void);
 
 - (instancetype)initWithCameraSensor:(PigeonSensorPosition)sensor
                         videoOptions:(nullable CupertinoVideoOptions *)videoOptions

--- a/lib/src/orchestrator/states/preparing_camera_state.dart
+++ b/lib/src/orchestrator/states/preparing_camera_state.dart
@@ -137,11 +137,9 @@ class PreparingCameraState extends CameraState {
       enableImageStream: cameraContext.imageAnalysisEnabled,
       enablePhysicalButton: cameraContext.enablePhysicalButton,
     );
-    // Start camera BEFORE changing state to ensure frames are flowing
-    // when the UI shows the record button. The native start() method
-    // blocks until the first frame is received.
-    await CamerawesomePlugin.start();
     cameraContext.changeState(VideoCameraState.from(cameraContext));
+
+    return CamerawesomePlugin.start();
   }
 
   Future _startPhotoMode() async {
@@ -150,10 +148,9 @@ class PreparingCameraState extends CameraState {
       enableImageStream: cameraContext.imageAnalysisEnabled,
       enablePhysicalButton: cameraContext.enablePhysicalButton,
     );
-    // Start camera BEFORE changing state to ensure frames are flowing.
-    // The native start() method blocks until the first frame is received.
-    await CamerawesomePlugin.start();
     cameraContext.changeState(PhotoCameraState.from(cameraContext));
+
+    return CamerawesomePlugin.start();
   }
 
   Future _startPreviewMode() async {
@@ -162,10 +159,9 @@ class PreparingCameraState extends CameraState {
       enableImageStream: cameraContext.imageAnalysisEnabled,
       enablePhysicalButton: cameraContext.enablePhysicalButton,
     );
-    // Start camera BEFORE changing state to ensure frames are flowing.
-    // The native start() method blocks until the first frame is received.
-    await CamerawesomePlugin.start();
     cameraContext.changeState(PreviewCameraState.from(cameraContext));
+
+    return CamerawesomePlugin.start();
   }
 
   Future _startAnalysisMode() async {


### PR DESCRIPTION
## Reverts PR #631

This reverts the audio pre-warming and first-frame synchronization changes introduced in PR #631.

## Problem

PR #631 added two mechanisms to fix first-recording desync:
1. **Audio pre-warming** during camera initialization (`setUpCaptureSessionForAudio` called eagerly in `start()`)
2. **First-frame semaphore** that blocked `start()` until the camera delivered its first frame

These changes introduced an intermittent bug where **recorded videos have no audio**. The audio stream does not reliably warm up and attach to recordings when set up eagerly during camera initialization. Reverting to the original on-demand audio setup in our app's fork resolved the issue.

## What Changed

### `SingleCameraPreview.m`
- Removed semaphore-based first-frame synchronization from `start()`
- Removed audio pre-warming during camera initialization
- Removed `onFirstFrameReceived` callback from `captureOutput:`
- Restored original simple `start()` method

### `SingleCameraPreview.h`
- Removed `onFirstFrameReceived` property declaration

### `preparing_camera_state.dart`
- Restored original ordering: `changeState()` before `CamerawesomePlugin.start()`
- `start()` is returned (fire-and-forget) instead of awaited

## Testing

1. Start video recording and speak clearly
2. Stop recording after ~10 seconds
3. Play back and verify audio is present
4. Repeat 10+ times to confirm no intermittent audio loss
5. Test with both front and back cameras

## Checklist

- [x]  📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x]  🤝 I match the actual coding style.
- [x]  ✅ I ran flutter analyze without any issues.