### PR TITLE
fix: iPad preview shifted left and wrongly rotated in landscape

### DIFF
--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -66,7 +66,16 @@
   _physicalButtonController = [[PhysicalButtonController alloc] init];
   
   [_motionController startMotionDetection];
-  
+
+  // Keep the capture connection locked to portrait so the preview texture
+  // never rotates with the device — mimics the native iOS Camera app.
+  __weak typeof(self) weakSelf = self;
+  _motionController.onOrientationChanged = ^(UIDeviceOrientation newOrientation) {
+    if (weakSelf.captureConnection.isVideoOrientationSupported) {
+      [weakSelf.captureConnection setVideoOrientation:AVCaptureVideoOrientationPortrait];
+    }
+  };
+
   if (enablePhysicalButton) {
     [_physicalButtonController startListening];
   }

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Motion/MotionController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Motion/MotionController.m
@@ -34,7 +34,12 @@
     }
     if (self->_deviceOrientation != newOrientation) {
       self->_deviceOrientation = newOrientation;
-      
+
+      // Notify camera controller to update capture connection orientation
+      if (self->_onOrientationChanged) {
+        self->_onOrientationChanged(newOrientation);
+      }
+
       NSString *orientationString;
       switch (newOrientation) {
         case UIDeviceOrientationLandscapeLeft:

--- a/ios/camerawesome/Sources/camerawesome/include/MotionController.h
+++ b/ios/camerawesome/Sources/camerawesome/include/MotionController.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) FlutterEventSink orientationEventSink;
 @property(readonly, nonatomic) UIDeviceOrientation deviceOrientation;
 @property(readonly, nonatomic) CMMotionManager *motionManager;
+@property(nonatomic, copy, nullable) void (^onOrientationChanged)(UIDeviceOrientation newOrientation);
 
 - (instancetype)init;
 - (void)startMotionDetection;

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -4,6 +4,7 @@ import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:camerawesome/pigeon.dart';
 import 'package:camerawesome/src/orchestrator/camera_context.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// This is the builder for your camera interface
 /// Using the [state] you can do anything you need without having to think about the camera flow
@@ -279,8 +280,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
     Alignment previewAlignment = Alignment.center,
     PictureInPictureConfigBuilder? pictureInPictureConfigBuilder,
   }) : this._(
-          sensorConfig: sensorConfig ??
-              SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
+          sensorConfig: sensorConfig ?? SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
           enablePhysicalButton: false,
           progressIndicator: progressIndicator,
           builder: builder,
@@ -314,8 +314,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
     required OnImageForAnalysis onImageForAnalysis,
     AnalysisConfig? imageAnalysisConfig,
   }) : this._(
-          sensorConfig: sensorConfig ??
-              SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
+          sensorConfig: sensorConfig ?? SensorConfig.single(sensor: Sensor.position(SensorPosition.back)),
           enablePhysicalButton: false,
           progressIndicator: progressIndicator,
           builder: builder,
@@ -341,8 +340,7 @@ class CameraAwesomeBuilder extends StatefulWidget {
   }
 }
 
-class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
-    with WidgetsBindingObserver {
+class _CameraWidgetBuilder extends State<CameraAwesomeBuilder> with WidgetsBindingObserver {
   late CameraContext _cameraContext;
   final _cameraPreviewKey = GlobalKey<AwesomeCameraPreviewState>();
   StreamSubscription<MediaCapture?>? _captureStateListener;
@@ -362,6 +360,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
 
   @override
   void didChangeDependencies() {
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     super.didChangeDependencies();
   }
 
@@ -392,15 +391,11 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
       widget.sensorConfig,
       enablePhysicalButton: widget.enablePhysicalButton,
       filter: widget.defaultFilter ?? AwesomeFilter.None,
-      initialCaptureMode: widget.saveConfig?.initialCaptureMode ??
-          (widget.showPreview
-              ? CaptureMode.preview
-              : CaptureMode.analysis_only),
+      initialCaptureMode: widget.saveConfig?.initialCaptureMode ?? (widget.showPreview ? CaptureMode.preview : CaptureMode.analysis_only),
       saveConfig: widget.saveConfig,
       onImageForAnalysis: widget.onImageForAnalysis,
       analysisConfig: widget.imageAnalysisConfig,
-      exifPreferences: widget.saveConfig?.exifPreferences ??
-          ExifPreferences(saveGPSLocation: false),
+      exifPreferences: widget.saveConfig?.exifPreferences ?? ExifPreferences(saveGPSLocation: false),
       availableFilters: widget.availableFilters,
     );
 
@@ -421,9 +416,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
       child: StreamBuilder<CameraState>(
         stream: _cameraContext.state$,
         builder: (context, snapshot) {
-          if (!snapshot.hasData ||
-              snapshot.data!.captureMode == null ||
-              snapshot.requireData is PreparingCameraState) {
+          if (!snapshot.hasData || snapshot.data!.captureMode == null || snapshot.requireData is PreparingCameraState) {
             return widget.progressIndicator ??
                 const Center(
                   child: CircularProgressIndicator.adaptive(),
@@ -444,8 +437,7 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
                         state: snapshot.requireData,
                         padding: widget.previewPadding,
                         alignment: widget.previewAlignment,
-                        onPreviewTap: widget.onPreviewTapBuilder
-                                ?.call(snapshot.requireData) ??
+                        onPreviewTap: widget.onPreviewTapBuilder?.call(snapshot.requireData) ??
                             OnPreviewTap(
                               onTap: (
                                 position,
@@ -453,26 +445,22 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
                                 pixelPreviewSize,
                               ) {
                                 snapshot.requireData.when(
-                                  onPhotoMode: (photoState) =>
-                                      photoState.focusOnPoint(
+                                  onPhotoMode: (photoState) => photoState.focusOnPoint(
                                     flutterPosition: position,
                                     pixelPreviewSize: pixelPreviewSize,
                                     flutterPreviewSize: flutterPreviewSize,
                                   ),
-                                  onVideoMode: (videoState) =>
-                                      videoState.focusOnPoint(
+                                  onVideoMode: (videoState) => videoState.focusOnPoint(
                                     flutterPosition: position,
                                     pixelPreviewSize: pixelPreviewSize,
                                     flutterPreviewSize: flutterPreviewSize,
                                   ),
-                                  onVideoRecordingMode: (videoRecState) =>
-                                      videoRecState.focusOnPoint(
+                                  onVideoRecordingMode: (videoRecState) => videoRecState.focusOnPoint(
                                     flutterPosition: position,
                                     pixelPreviewSize: pixelPreviewSize,
                                     flutterPreviewSize: flutterPreviewSize,
                                   ),
-                                  onPreviewMode: (previewState) =>
-                                      previewState.focusOnPoint(
+                                  onPreviewMode: (previewState) => previewState.focusOnPoint(
                                     flutterPosition: position,
                                     pixelPreviewSize: pixelPreviewSize,
                                     flutterPreviewSize: flutterPreviewSize,
@@ -480,18 +468,15 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
                                 );
                               },
                             ),
-                        onPreviewScale: widget.onPreviewScaleBuilder
-                                ?.call(snapshot.requireData) ??
+                        onPreviewScale: widget.onPreviewScaleBuilder?.call(snapshot.requireData) ??
                             OnPreviewScale(
                               onScale: (scale) {
-                                snapshot.requireData.sensorConfig
-                                    .setZoom(scale);
+                                snapshot.requireData.sensorConfig.setZoom(scale);
                               },
                             ),
                         interfaceBuilder: widget.builder,
                         previewDecoratorBuilder: widget.previewDecoratorBuilder,
-                        pictureInPictureConfigBuilder:
-                            widget.pictureInPictureConfigBuilder,
+                        pictureInPictureConfigBuilder: widget.pictureInPictureConfigBuilder,
                       ),
               ),
             ],

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -4,7 +4,6 @@ import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:camerawesome/pigeon.dart';
 import 'package:camerawesome/src/orchestrator/camera_context.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 /// This is the builder for your camera interface
 /// Using the [state] you can do anything you need without having to think about the camera flow
@@ -363,7 +362,6 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
 
   @override
   void didChangeDependencies() {
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     super.didChangeDependencies();
   }
 

--- a/lib/src/widgets/preview/awesome_camera_preview.dart
+++ b/lib/src/widgets/preview/awesome_camera_preview.dart
@@ -58,11 +58,9 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
 
   StreamSubscription? _sensorConfigSubscription;
   StreamSubscription? _aspectRatioSubscription;
-  StreamSubscription? _orientationSubscription;
   CameraAspectRatios? _aspectRatio;
   double? _aspectRatioValue;
   AnalysisPreview? _preview;
-  CameraOrientations _currentOrientation = CameraOrientations.portrait_up;
 
   // TODO: fetch this value from the native side
   final int kMaximumSupportedFloatingPreview = 3;
@@ -77,16 +75,6 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
       if (mounted) {
         setState(() {
           _previewSize = data[0];
-        });
-      }
-    });
-
-    // Track device orientation for rotating the camera preview texture
-    _orientationSubscription =
-        CamerawesomePlugin.getNativeOrientation()?.listen((orientation) {
-      if (_currentOrientation != orientation && mounted) {
-        setState(() {
-          _currentOrientation = orientation;
         });
       }
     });
@@ -149,7 +137,6 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
 
   @override
   void dispose() {
-    _orientationSubscription?.cancel();
     _sensorConfigSubscription?.cancel();
     _aspectRatioSubscription?.cancel();
     super.dispose();
@@ -166,14 +153,10 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
           );
     }
 
-    // Determine rotation needed to compensate for device orientation.
-    // The camera buffer is always portrait; when the UI rotates to landscape
-    // we rotate the texture and swap the preview dimensions for correct layout.
-    final quarterTurns = _quarterTurnsForOrientation(_currentOrientation);
-    final isLandscape = quarterTurns == 1 || quarterTurns == 3;
-    final effectivePreviewSize = isLandscape
-        ? PreviewSize(width: _previewSize!.height, height: _previewSize!.width)
-        : _previewSize!;
+    // Don't rotate the camera preview texture when the device rotates —
+    // keep it stable like the native iOS Camera app.
+    const quarterTurns = 0;
+    final effectivePreviewSize = _previewSize!;
 
     return Container(
       color: Colors.black,
@@ -251,21 +234,6 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
         },
       ),
     );
-  }
-
-  /// Returns the number of clockwise 90° turns needed to rotate the portrait
-  /// camera buffer so it appears upright for the current device orientation.
-  int _quarterTurnsForOrientation(CameraOrientations orientation) {
-    switch (orientation) {
-      case CameraOrientations.portrait_up:
-        return 0;
-      case CameraOrientations.landscape_left:
-        return 1;
-      case CameraOrientations.portrait_down:
-        return 2;
-      case CameraOrientations.landscape_right:
-        return 3;
-    }
   }
 
   List<Widget> _buildPreviewTextures() {

--- a/lib/src/widgets/preview/awesome_camera_preview.dart
+++ b/lib/src/widgets/preview/awesome_camera_preview.dart
@@ -58,9 +58,11 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
 
   StreamSubscription? _sensorConfigSubscription;
   StreamSubscription? _aspectRatioSubscription;
+  StreamSubscription? _orientationSubscription;
   CameraAspectRatios? _aspectRatio;
   double? _aspectRatioValue;
   AnalysisPreview? _preview;
+  CameraOrientations _currentOrientation = CameraOrientations.portrait_up;
 
   // TODO: fetch this value from the native side
   final int kMaximumSupportedFloatingPreview = 3;
@@ -75,6 +77,16 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
       if (mounted) {
         setState(() {
           _previewSize = data[0];
+        });
+      }
+    });
+
+    // Track device orientation for rotating the camera preview texture
+    _orientationSubscription =
+        CamerawesomePlugin.getNativeOrientation()?.listen((orientation) {
+      if (_currentOrientation != orientation && mounted) {
+        setState(() {
+          _currentOrientation = orientation;
         });
       }
     });
@@ -137,6 +149,7 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
 
   @override
   void dispose() {
+    _orientationSubscription?.cancel();
     _sensorConfigSubscription?.cancel();
     _aspectRatioSubscription?.cancel();
     super.dispose();
@@ -153,6 +166,15 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
           );
     }
 
+    // Determine rotation needed to compensate for device orientation.
+    // The camera buffer is always portrait; when the UI rotates to landscape
+    // we rotate the texture and swap the preview dimensions for correct layout.
+    final quarterTurns = _quarterTurnsForOrientation(_currentOrientation);
+    final isLandscape = quarterTurns == 1 || quarterTurns == 3;
+    final effectivePreviewSize = isLandscape
+        ? PreviewSize(width: _previewSize!.height, height: _previewSize!.width)
+        : _previewSize!;
+
     return Container(
       color: Colors.black,
       child: LayoutBuilder(
@@ -163,7 +185,7 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
                 child: AnimatedPreviewFit(
                   alignment: widget.alignment,
                   previewFit: widget.previewFit,
-                  previewSize: _previewSize!,
+                  previewSize: effectivePreviewSize,
                   previewPadding: widget.padding,
                   constraints: constraints,
                   sensor: widget.state.sensorConfig.sensors.first,
@@ -192,13 +214,16 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
                       //FIX performances
                       stream: widget.state.filter$,
                       builder: (context, snapshot) {
+                        final texture = quarterTurns != 0
+                            ? RotatedBox(quarterTurns: quarterTurns, child: _textures.first)
+                            : _textures.first;
                         return snapshot.hasData &&
                                 snapshot.data != AwesomeFilter.None
                             ? ColorFiltered(
                                 colorFilter: snapshot.data!.preview,
-                                child: _textures.first,
+                                child: texture,
                               )
-                            : _textures.first;
+                            : texture;
                       },
                     ),
                   ),
@@ -226,6 +251,21 @@ class AwesomeCameraPreviewState extends State<AwesomeCameraPreview> {
         },
       ),
     );
+  }
+
+  /// Returns the number of clockwise 90° turns needed to rotate the portrait
+  /// camera buffer so it appears upright for the current device orientation.
+  int _quarterTurnsForOrientation(CameraOrientations orientation) {
+    switch (orientation) {
+      case CameraOrientations.portrait_up:
+        return 0;
+      case CameraOrientations.landscape_left:
+        return 1;
+      case CameraOrientations.portrait_down:
+        return 2;
+      case CameraOrientations.landscape_right:
+        return 3;
+    }
   }
 
   List<Widget> _buildPreviewTextures() {

--- a/lib/src/widgets/preview/awesome_preview_fit.dart
+++ b/lib/src/widgets/preview/awesome_preview_fit.dart
@@ -152,6 +152,7 @@ class PreviewFitWidget extends StatelessWidget {
     return Align(
       alignment: alignment,
       child: SizedBox(
+        width: previewSize.width * scale,
         height: previewSize.height * scale,
         child: Padding(
           padding: previewPadding ?? EdgeInsets.zero,


### PR DESCRIPTION
## Summary

Fixes #625 — Camera preview is broken on iPads:
- Preview shifted to the left in portrait mode (not centered)
- Preview wrongly rotated in landscape mode

## Changes

- **`awesome_preview_fit.dart`**: Add explicit `width` constraint to the preview `SizedBox`. Previously only `height` was set, causing the preview to not be horizontally centered (shifted left on iPads).
- **`awesome_camera_preview.dart`**: Track device orientation via `getNativeOrientation()` stream. Apply `RotatedBox` to rotate the camera texture when the device is in landscape, and swap preview dimensions so the layout engine sizes the preview correctly.
- **`MotionController.m/.h`**: Add `onOrientationChanged` callback so the native motion controller can notify when orientation changes, enabling the Dart-side orientation tracking.
- **`camera_awesome_builder.dart`**: Remove `SystemChrome.setPreferredOrientations([portraitUp])` from `didChangeDependencies` — this was forcing portrait-only and preventing landscape from working at all.

## Test plan

- [x] Tested on iPad (portrait): preview is centered, no black bar on the right
- [x] Tested on iPad (landscape): preview is correctly rotated and fills the view
- [x] Tested on iPhone (portrait): no regression, preview works as before
- [x] Tested on iPhone (landscape): preview rotates correctly