### PR TITLE
feat(ios): make microphone & location features opt-out (fixes ITMS-90683)

### DIFF
--- a/ios/camerawesome.podspec
+++ b/ios/camerawesome.podspec
@@ -22,4 +22,26 @@ An open source camera plugin by the community for the community
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   #   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
   s.swift_version = '5.0'
+
+  # Optional compile-time feature gates.
+  #
+  # Consumers that don't record video audio or save GPS to EXIF can strip
+  # the microphone / CoreLocation references from the compiled binary —
+  # this eliminates the App Store Connect ITMS-90683 warning for the
+  # corresponding Info.plist purpose strings.
+  #
+  # Activate from your app Podfile, e.g.:
+  #
+  #   post_install do |installer|
+  #     installer.pods_project.targets.each do |target|
+  #       next unless target.name == 'camerawesome'
+  #       target.build_configurations.each do |config|
+  #         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+  #         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'CAMERAWESOME_DISABLE_MICROPHONE=1'
+  #         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'CAMERAWESOME_DISABLE_LOCATION=1'
+  #       end
+  #     end
+  #   end
+  #
+  # Defaults: both features enabled (backwards compatible).
 end

--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -6,6 +6,7 @@
 //
 
 #import "SingleCameraPreview.h"
+#import "CamerawesomeCompileOptions.h"
 
 @implementation SingleCameraPreview {
   dispatch_queue_t _dispatchQueue;
@@ -567,16 +568,17 @@
 
 /// Set audio recording mode
 - (void)setRecordingAudioMode:(bool)isAudioEnabled completion:(void(^)(NSNumber *_Nullable, FlutterError *_Nullable))completion {
+#if CAMERAWESOME_USE_MICROPHONE
   if (_videoController.isRecording) {
     completion(@(NO), [FlutterError errorWithCode:@"CHANGE_AUDIO_MODE" message:@"impossible to change audio mode, video already recording" details:@""]);
     return;
   }
-  
+
   [_captureSession beginConfiguration];
   [_videoController setIsAudioEnabled:isAudioEnabled];
   [_videoController setIsAudioSetup:NO];
   [_videoController setAudioIsDisconnected:YES];
-  
+
   // Only remove audio channel input but keep video
   for (AVCaptureInput *input in [_captureSession inputs]) {
     for (AVCaptureInputPort *port in input.ports) {
@@ -588,20 +590,26 @@
   }
   // Only remove audio channel output but keep video
   [_captureSession removeOutput:_audioOutput];
-  
+
   if (_videoController.isRecording) {
     [self setUpCaptureSessionForAudioError:^(NSError *error) {
       completion(@(NO), [FlutterError errorWithCode:@"VIDEO_ERROR" message:@"error when trying to setup audio" details:[error localizedDescription]]);
     }];
   }
-  
+
   [_captureSession commitConfiguration];
   completion(@(YES), nil);
+#else
+  // Microphone support compiled out; audio recording is permanently disabled.
+  [_videoController setIsAudioEnabled:NO];
+  completion(@(NO), nil);
+#endif
 }
 
 # pragma mark - Audio
 /// Setup audio channel to record audio
 - (void)setUpCaptureSessionForAudioError:(nonnull void (^)(NSError *))error {
+#if CAMERAWESOME_USE_MICROPHONE
   NSError *audioError = nil;
   // Create a device input with the device and add it to the session.
   // Setup the audio input.
@@ -611,13 +619,13 @@
   if (audioError) {
     error(audioError);
   }
-  
+
   // Setup the audio output.
   _audioOutput = [[AVCaptureAudioDataOutput alloc] init];
-  
+
   if ([_captureSession canAddInput:audioInput]) {
     [_captureSession addInput:audioInput];
-    
+
     if ([_captureSession canAddOutput:_audioOutput]) {
       [_captureSession addOutput:_audioOutput];
       [_videoController setIsAudioSetup:YES];
@@ -625,6 +633,10 @@
       [_videoController setIsAudioSetup:NO];
     }
   }
+#else
+  // Microphone support compiled out; no audio capture session is configured.
+  [_videoController setIsAudioSetup:NO];
+#endif
 }
 
 # pragma mark - Camera Delegates

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Exif/ExifContainer.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Exif/ExifContainer.m
@@ -6,8 +6,10 @@
 //
 
 #import <ImageIO/ImageIO.h>
-#import <CoreLocation/CoreLocation.h>
 #import "ExifContainer.h"
+#if CAMERAWESOME_USE_LOCATION
+#import <CoreLocation/CoreLocation.h>
+#endif
 
 NSString const * kCGImagePropertyProjection = @"ProjectionType";
 
@@ -32,6 +34,7 @@ NSString const * kCGImagePropertyProjection = @"ProjectionType";
   return self;
 }
 
+#if CAMERAWESOME_USE_LOCATION
 - (void)addLocation:(CLLocation *)currentLocation {
   CLLocationDegrees latitude  = currentLocation.coordinate.latitude;
   CLLocationDegrees longitude = currentLocation.coordinate.longitude;
@@ -66,6 +69,7 @@ NSString const * kCGImagePropertyProjection = @"ProjectionType";
   self.gpsDictionary[(NSString*)kCGImagePropertyGPSDOP] = [NSNumber numberWithFloat:currentLocation.horizontalAccuracy];
   self.gpsDictionary[(NSString*)kCGImagePropertyGPSAltitude] = [NSNumber numberWithFloat:currentLocation.altitude];
 }
+#endif
 
 - (void)addUserComment:(NSString*)comment {
   NSString *key = (__bridge_transfer NSString *)kCGImagePropertyExifUserComment;

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Location/LocationController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Location/LocationController.m
@@ -7,24 +7,26 @@
 
 #import "LocationController.h"
 
+#if CAMERAWESOME_USE_LOCATION
+
 @implementation LocationController
 
 - (instancetype)init {
   if (self = [super init]) {
     self.locationManager = [[CLLocationManager alloc] init];
     self.locationManager.delegate = self;
-    
+
     self.locationManager.distanceFilter = kCLDistanceFilterNone;
     self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;
   }
-  
+
   return self;
 }
 
 - (void)requestWhenInUseAuthorizationOnGranted:(OnAuthorizationGranted)granted declined:(OnAuthorizationDeclined)declined {
   _grantedBlock = granted;
   _declinedBlock = declined;
-  
+
   if (self.locationManager.authorizationStatus ==  kCLAuthorizationStatusNotDetermined) {
     if ([self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
       [self.locationManager requestWhenInUseAuthorization];
@@ -41,13 +43,34 @@
     if (_grantedBlock != nil) {
       _grantedBlock();
     }
-    
+
   } else {
     if (_declinedBlock != nil) {
       _declinedBlock();
     }
-    
+
   }
 }
 
 @end
+
+#else
+
+// Stub implementation when CAMERAWESOME_DISABLE_LOCATION=1.
+// Always declines any authorization request so callers fall back to
+// the "no GPS in EXIF" path without ever touching CoreLocation.
+@implementation LocationController
+
+- (instancetype)init {
+  return [super init];
+}
+
+- (void)requestWhenInUseAuthorizationOnGranted:(OnAuthorizationGranted)granted declined:(OnAuthorizationDeclined)declined {
+  if (declined != nil) {
+    declined();
+  }
+}
+
+@end
+
+#endif

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Permissions/PermissionsController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Permissions/PermissionsController.m
@@ -6,6 +6,7 @@
 //
 
 #import "PermissionsController.h"
+#import "CamerawesomeCompileOptions.h"
 
 @implementation CameraPermissionsController
 
@@ -38,15 +39,17 @@
 
 @implementation MicrophonePermissionsController
 
+#if CAMERAWESOME_USE_MICROPHONE
+
 + (BOOL)checkPermission {
   AVAudioSessionRecordPermission permissionStatus = [[AVAudioSession sharedInstance] recordPermission];
-  
+
   return (permissionStatus == AVAudioSessionRecordPermissionGranted);
 }
 
 + (BOOL)checkAndRequestPermission {
   AVAudioSessionRecordPermission permissionStatus = [[AVAudioSession sharedInstance] recordPermission];
-  
+
   __block BOOL permissionsGranted;
   if (permissionStatus == AVAudioSessionRecordPermissionUndetermined) {
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
@@ -58,8 +61,22 @@
   } else {
     permissionsGranted = (permissionStatus == AVAudioSessionRecordPermissionGranted);
   }
-  
+
   return permissionsGranted;
 }
+
+#else
+
+// Stubs when CAMERAWESOME_DISABLE_MICROPHONE=1. The microphone permission is
+// reported as denied so callers fall back to audio-less recording paths.
++ (BOOL)checkPermission {
+  return NO;
+}
+
++ (BOOL)checkAndRequestPermission {
+  return NO;
+}
+
+#endif
 
 @end

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Picture/CameraPictureController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Picture/CameraPictureController.m
@@ -89,12 +89,14 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   ExifContainer *container = [[ExifContainer alloc] init];
   [container addCreationDate:[NSDate date]];
   
-  // Save GPS location only if provided
+  // Save GPS location only if provided (and compiled with location support)
+#if CAMERAWESOME_USE_LOCATION
   if (_saveGPSLocation) {
     CLLocationManager *locationManager = [CLLocationManager new];
     CLLocation *location = [locationManager location];
     [container addLocation:location];
   }
+#endif
   
   // we ignore this error because plugin can only be installed on iOS 11+
 #pragma clang diagnostic push

--- a/ios/camerawesome/Sources/camerawesome/Controllers/Video/VideoController.m
+++ b/ios/camerawesome/Sources/camerawesome/Controllers/Video/VideoController.m
@@ -6,6 +6,7 @@
 //
 
 #import "VideoController.h"
+#import "CamerawesomeCompileOptions.h"
 
 FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 
@@ -14,7 +15,11 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 - (instancetype)init {
   self = [super init];
   _isRecording = NO;
+#if CAMERAWESOME_USE_MICROPHONE
   _isAudioEnabled = YES;
+#else
+  _isAudioEnabled = NO;
+#endif
   _isPaused = NO;
   
   return self;
@@ -129,12 +134,13 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   
   [_videoWriter addInput:_videoWriterInput];
   
+#if CAMERAWESOME_USE_MICROPHONE
   if (_isAudioEnabled) {
     AudioChannelLayout acl;
     bzero(&acl, sizeof(acl));
     acl.mChannelLayoutTag = kAudioChannelLayoutTag_Mono;
     NSDictionary *audioOutputSettings = nil;
-    
+
     audioOutputSettings = [NSDictionary
                            dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:kAudioFormatMPEG4AAC], AVFormatIDKey,
                            [NSNumber numberWithFloat:44100.0], AVSampleRateKey,
@@ -144,9 +150,10 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
     _audioWriterInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
                                                            outputSettings:audioOutputSettings];
     _audioWriterInput.expectsMediaDataInRealTime = YES;
-    
+
     [_videoWriter addInput:_audioWriterInput];
   }
+#endif
   
   return YES;
 }

--- a/ios/camerawesome/Sources/camerawesome/include/CameraPictureController.h
+++ b/ios/camerawesome/Sources/camerawesome/include/CameraPictureController.h
@@ -9,7 +9,10 @@
 #import <AVFoundation/AVFoundation.h>
 #import <Foundation/Foundation.h>
 #import <CoreMotion/CoreMotion.h>
+#import "CamerawesomeCompileOptions.h"
+#if CAMERAWESOME_USE_LOCATION
 #import <CoreLocation/CoreLocation.h>
+#endif
 
 #import "CameraSensor.h"
 #import "AspectRatio.h"

--- a/ios/camerawesome/Sources/camerawesome/include/CamerawesomeCompileOptions.h
+++ b/ios/camerawesome/Sources/camerawesome/include/CamerawesomeCompileOptions.h
@@ -1,0 +1,46 @@
+//
+//  CamerawesomeCompileOptions.h
+//  camerawesome
+//
+//  Compile-time feature gates so consumers can strip optional iOS APIs
+//  (microphone, location) from the binary. This eliminates the App Store
+//  Connect ITMS-90683 warning for apps that do not record video audio or
+//  embed GPS in EXIF.
+//
+//  Activate by setting the matching preprocessor flag from a consumer
+//  Podfile (post_install hook), e.g.:
+//
+//    post_install do |installer|
+//      installer.pods_project.targets.each do |target|
+//        next unless target.name == 'camerawesome'
+//        target.build_configurations.each do |config|
+//          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+//          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'CAMERAWESOME_DISABLE_MICROPHONE=1'
+//          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'CAMERAWESOME_DISABLE_LOCATION=1'
+//        end
+//      end
+//    end
+//
+//  Default: both features enabled (backwards compatible).
+//
+
+#ifndef CamerawesomeCompileOptions_h
+#define CamerawesomeCompileOptions_h
+
+#ifndef CAMERAWESOME_USE_MICROPHONE
+  #if defined(CAMERAWESOME_DISABLE_MICROPHONE) && CAMERAWESOME_DISABLE_MICROPHONE
+    #define CAMERAWESOME_USE_MICROPHONE 0
+  #else
+    #define CAMERAWESOME_USE_MICROPHONE 1
+  #endif
+#endif
+
+#ifndef CAMERAWESOME_USE_LOCATION
+  #if defined(CAMERAWESOME_DISABLE_LOCATION) && CAMERAWESOME_DISABLE_LOCATION
+    #define CAMERAWESOME_USE_LOCATION 0
+  #else
+    #define CAMERAWESOME_USE_LOCATION 1
+  #endif
+#endif
+
+#endif /* CamerawesomeCompileOptions_h */

--- a/ios/camerawesome/Sources/camerawesome/include/ExifContainer.h
+++ b/ios/camerawesome/Sources/camerawesome/include/ExifContainer.h
@@ -6,14 +6,19 @@
 //  Taken from: https://github.com/Nikita2k/SimpleExif
 
 #import <Foundation/Foundation.h>
+#import "CamerawesomeCompileOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if CAMERAWESOME_USE_LOCATION
 @class CLLocation;
+#endif
 
 @interface ExifContainer : NSObject
 
+#if CAMERAWESOME_USE_LOCATION
 - (void)addLocation:(CLLocation *)currentLocation;
+#endif
 - (void)addUserComment:(NSString *)comment;
 - (void)addCreationDate:(NSDate *)date;
 - (void)addDescription:(NSString *)description;

--- a/ios/camerawesome/Sources/camerawesome/include/LocationController.h
+++ b/ios/camerawesome/Sources/camerawesome/include/LocationController.h
@@ -7,12 +7,17 @@
 
 #import <Flutter/Flutter.h>
 #import <Foundation/Foundation.h>
+#import "CamerawesomeCompileOptions.h"
+#if CAMERAWESOME_USE_LOCATION
 #import <CoreLocation/CoreLocation.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^OnAuthorizationDeclined)(void);
 typedef void(^OnAuthorizationGranted)(void);
+
+#if CAMERAWESOME_USE_LOCATION
 
 @interface LocationController : NSObject<CLLocationManagerDelegate>
 
@@ -24,5 +29,19 @@ typedef void(^OnAuthorizationGranted)(void);
 - (void)requestWhenInUseAuthorizationOnGranted:(OnAuthorizationGranted)granted declined:(OnAuthorizationDeclined)declined;
 
 @end
+
+#else
+
+// Stub interface when location support is compiled out. Keeps the public
+// surface so call sites in SingleCameraPreview / MultiCameraPreview /
+// CamerawesomePlugin still compile without further #ifdef churn.
+@interface LocationController : NSObject
+
+- (instancetype)init;
+- (void)requestWhenInUseAuthorizationOnGranted:(OnAuthorizationGranted)granted declined:(OnAuthorizationDeclined)declined;
+
+@end
+
+#endif
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary

Adds two preprocessor flags so consumers can strip Apple-privacy-sensitive code paths from the compiled binary, eliminating App Store Connect's **ITMS-90683** warnings for `NSMicrophoneUsageDescription` / `NSLocationWhenInUseUsageDescription` in apps that only use camerawesome for still photo capture:

- `CAMERAWESOME_DISABLE_MICROPHONE=1` — removes `AVAudioSession`, `AVCaptureDevice` audio inputs, and the audio writer setup. `isAudioEnabled` is forced to `NO`.
- `CAMERAWESOME_DISABLE_LOCATION=1` — removes `CLLocationManager`, `CoreLocation` imports, and the GPS-to-EXIF write path. `LocationController` keeps its public surface as a stub that always declines authorization, so call sites compile unchanged.

Both default to **enabled** — fully backwards compatible.

## Why

Apps that don't record video audio or geotag photos still trip Apple's static analyzer because the plugin's native sources unconditionally reference these APIs. Today the only fix is to ship Info.plist purpose strings the app will never use, which is misleading to reviewers and to end users.

This mirrors the pattern long established by [`permission_handler`](https://github.com/Baseflow/flutter-permission-handler) — flags wired through `GCC_PREPROCESSOR_DEFINITIONS` from the consumer Podfile (see `camerawesome.podspec` header comment for the snippet).

## Verified

Built a real Flutter app that consumes this fork with both flags on:

```
$ nm -u Runner.app/Frameworks/camerawesome.framework/camerawesome | grep -iE "AVAudioSession|CLLocation"
(none)
```

Building with defaults (no flags) is byte-for-byte the same as master.

## Files

| File | Change |
| --- | --- |
| `include/CamerawesomeCompileOptions.h` | New — declares the two `CAMERAWESOME_USE_*` macros |
| `include/LocationController.h` / `.m` | Stub interface + impl when location is disabled |
| `include/ExifContainer.h` / `.m` | Gate `addLocation:` and `CoreLocation` import |
| `include/CameraPictureController.h` / `.m` | Gate `CoreLocation` import + GPS-save block |
| `Controllers/Permissions/PermissionsController.m` | Stub `MicrophonePermissionsController` to return `NO` |
| `Controllers/Video/VideoController.m` | Gate audio writer input setup |
| `CameraPreview/SingleCameraPreview/SingleCameraPreview.m` | Gate `setRecordingAudioMode` body + audio session setup |
| `camerawesome.podspec` | Adds documentation block on activating the flags |

## Test plan

- [x] Build with defaults — behavior unchanged
- [x] Build with `CAMERAWESOME_DISABLE_MICROPHONE=1 CAMERAWESOME_DISABLE_LOCATION=1` — binary contains no `AVAudioSession` / `CLLocationManager` references
- [ ] Confirm App Store Connect no longer flags ITMS-90683 after upload (will report back after next TestFlight push)

Android is unchanged in this PR — happy to add equivalent gating in a follow-up if you'd accept the iOS half first.