### PR TITLE
fix(android): guard zoom reset before camera init

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -600,6 +600,10 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
     }
 
     override fun setZoom(zoom: Double) {
+        if (!::cameraState.isInitialized) {
+            Log.w(CamerawesomePlugin.TAG, "Ignoring setZoom before cameraState initialization")
+            return
+        }
         cameraState.setZoom(zoom.toFloat())
     }
 
@@ -633,6 +637,10 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
      * @return the max zoom ratio
      */
     override fun getMaxZoom(): Double {
+        if (!::cameraState.isInitialized) {
+            Log.w(CamerawesomePlugin.TAG, "Ignoring getMaxZoom before cameraState initialization")
+            return 1.0
+        }
         return cameraState.maxZoomRatio
     }
 
@@ -642,6 +650,10 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
      * @return the min zoom ratio
      */
     override fun getMinZoom(): Double {
+        if (!::cameraState.isInitialized) {
+            Log.w(CamerawesomePlugin.TAG, "Ignoring getMinZoom before cameraState initialization")
+            return 1.0
+        }
         return cameraState.minZoomRatio
     }
 

--- a/lib/src/widgets/camera_awesome_builder.dart
+++ b/lib/src/widgets/camera_awesome_builder.dart
@@ -371,7 +371,9 @@ class _CameraWidgetBuilder extends State<CameraAwesomeBuilder>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        _cameraContext.sensorConfig.setZoomToOneX();
+        if (_cameraContext.state is! PreparingCameraState) {
+          _cameraContext.sensorConfig.setZoomToOneX();
+        }
         break;
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:


### PR DESCRIPTION
## Summary
- skip the Android resume-time 1x zoom reset while the Dart camera state is still preparing
- guard Android native zoom calls before CameraX `cameraState` has been initialized

## Why
Crashlytics showed a fatal `CameraInterface.getMinZoom` failure when the Android permission dialog closed and the app resumed before native CameraX state existed. Returning neutral zoom bounds before initialization makes the startup reset a no-op instead of a crash.

## Validation
- `flutter analyze lib/src/widgets/camera_awesome_builder.dart`
- `flutter test test/filter_test.dart`

Full `flutter analyze` still reports the existing `awesome_preview_fit.dart` deprecated `scale` info. Full `flutter test` still fails to load the existing `test/camera_context_test.dart` because it has no `main` method.
