### PR TITLE
Smooth pinch-to-zoom: proportional gesture + geometric zoom curve

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraXState.kt
@@ -342,7 +342,17 @@ data class CameraXState(
         val zoomState = mainCameraInfos.zoomState.value ?: return
         val minZoomRatio = zoomState.minZoomRatio
         val maxZoomRatio = zoomState.maxZoomRatio
-        val targetZoomRatio = minZoomRatio + (maxZoomRatio - minZoomRatio) * clampedZoom
+        // Geometric mapping so equal finger travel gives equal *perceived* zoom
+        // change. A plain linear map crams the whole useful low-zoom range into
+        // the first few percent of the gesture, making the zoom feel jumpy.
+        val targetZoomRatio = if (minZoomRatio > 0f) {
+            minZoomRatio * Math.pow(
+                (maxZoomRatio / minZoomRatio).toDouble(),
+                clampedZoom.toDouble()
+            ).toFloat()
+        } else {
+            minZoomRatio + (maxZoomRatio - minZoomRatio) * clampedZoom
+        }
         mainCameraControl.setZoomRatio(targetZoomRatio)
     }
 

--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/MultiCameraPreview/MultiCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/MultiCameraPreview/MultiCameraPreview.m
@@ -87,8 +87,11 @@
   AVCaptureDevice *mainDevice = self.devices.firstObject.device;
   
   CGFloat maxZoom = [self getMaxZoom];
-  CGFloat scaledZoom = value * (maxZoom - 1.0f) + 1.0f;
-  
+  // Geometric mapping so equal finger travel gives equal *perceived* zoom
+  // change (see SingleCameraPreview.setZoom). minZoom is always 1.0 here.
+  CGFloat clampedValue = MAX(0.0f, MIN(1.0f, value));
+  CGFloat scaledZoom = pow(maxZoom, clampedValue);
+
   NSError *zoomError;
   if ([mainDevice lockForConfiguration:&zoomError]) {
     mainDevice.videoZoomFactor = scaledZoom;

--- a/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
+++ b/ios/camerawesome/Sources/camerawesome/CameraPreview/SingleCameraPreview/SingleCameraPreview.m
@@ -339,8 +339,13 @@
 /// Set zoom level
 - (void)setZoom:(float)value error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
   CGFloat maxZoom = [self getMaxZoom];
-  CGFloat scaledZoom = value * (maxZoom - 1.0f) + 1.0f;
-  
+  // Geometric mapping so equal finger travel gives equal *perceived* zoom
+  // change. A plain linear map (value * (maxZoom - 1) + 1) crams the whole
+  // useful low-zoom range into the first few percent of the gesture, which
+  // makes the zoom feel jumpy. minZoom is always 1.0 here.
+  CGFloat clampedValue = MAX(0.0f, MIN(1.0f, value));
+  CGFloat scaledZoom = pow(maxZoom, clampedValue);
+
   NSError *zoomError;
   if ([_captureDevice lockForConfiguration:&zoomError]) {
     _captureDevice.videoZoomFactor = scaledZoom;

--- a/lib/src/orchestrator/models/sensor_config.dart
+++ b/lib/src/orchestrator/models/sensor_config.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:rxdart/rxdart.dart';
@@ -113,9 +114,13 @@ class SensorConfig {
     final minZoom = await CamerawesomePlugin.getMinZoom();
     final maxZoom = await CamerawesomePlugin.getMaxZoom();
     if (minZoom == null || maxZoom == null || maxZoom <= minZoom) return;
-    if (minZoom < 1.0 && maxZoom >= 1.0) {
-      final oneXLinearZoom =
-          ((1.0 - minZoom) / (maxZoom - minZoom)).clamp(0.0, 1.0).toDouble();
+    if (minZoom < 1.0 && maxZoom >= 1.0 && minZoom > 0.0) {
+      // Inverse of the geometric mapping used natively
+      // (ratio = minZoom * (maxZoom / minZoom) ^ normalized): solve for the
+      // normalized value that yields a 1.0x ratio.
+      final oneXLinearZoom = (-math.log(minZoom) / (math.log(maxZoom) - math.log(minZoom)))
+          .clamp(0.0, 1.0)
+          .toDouble();
       if (oneXLinearZoom > 0.0) {
         await setZoom(oneXLinearZoom);
       }

--- a/lib/src/widgets/preview/awesome_camera_gesture_detector.dart
+++ b/lib/src/widgets/preview/awesome_camera_gesture_detector.dart
@@ -67,8 +67,21 @@ class AwesomeCameraGestureDetector extends StatefulWidget {
 class _AwesomeCameraGestureDetector
     extends State<AwesomeCameraGestureDetector> {
   double _zoomScale = 0;
-  final double _accuracy = 0.01;
-  double? _lastScale;
+
+  /// Zoom level captured when a pinch gesture starts, used as the anchor so the
+  /// zoom maps proportionally to finger spread instead of stepping by a fixed
+  /// increment (which felt jerky).
+  double _baseZoom = 0;
+
+  /// Scale reported on the first genuine two-finger frame. We anchor to this
+  /// instead of assuming the gesture begins at 1.0: when the two fingers don't
+  /// land at the exact same instant the recognizer's first reported scale can
+  /// already be far from 1.0, which otherwise makes the zoom jump straight to
+  /// max.
+  double? _startScale;
+
+  /// How aggressively finger spread maps to zoom. Higher = faster zoom.
+  static const double _sensitivity = 0.6;
 
   Offset? _tapPosition;
   Timer? _timer;
@@ -88,22 +101,21 @@ class _AwesomeCameraGestureDetector
               GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
             () => ScaleGestureRecognizer()
               ..onStart = (_) {
-                _lastScale = null;
+                _baseZoom = _zoomScale;
+                _startScale = null;
               }
               ..onUpdate = (ScaleUpdateDetails details) {
-                _lastScale ??= details.scale;
-                if (details.scale < (_lastScale! + 0.01) &&
-                    details.scale > (_lastScale! - 0.01)) {
-                  return;
-                } else if (_lastScale! < details.scale) {
-                  _zoomScale += _accuracy;
-                } else {
-                  _zoomScale -= _accuracy;
-                }
-
-                _zoomScale = _zoomScale.clamp(0, 1);
+                // Ignore single-finger frames (scale is always 1.0 there and
+                // would seed a wrong anchor).
+                if (details.pointerCount < 2) return;
+                // Anchor to the first real two-finger frame so the zoom delta
+                // starts at 0 regardless of what absolute scale the recognizer
+                // reports first. details.scale > anchor => zoom in, < => out.
+                _startScale ??= details.scale;
+                _zoomScale =
+                    (_baseZoom + (details.scale - _startScale!) * _sensitivity)
+                        .clamp(0.0, 1.0);
                 widget.onPreviewScale!.onScale(_zoomScale);
-                _lastScale = details.scale;
               },
             (instance) {},
           ),


### PR DESCRIPTION
The pinch gesture felt jerky and jumped toward max zoom. Two root causes:

1. The gesture detector stepped zoom by a fixed ±0.01 increment per scale update instead of mapping finger spread proportionally, and assumed the gesture started at scale 1.0 (the recognizer's first reported scale can be far from 1.0 when fingers don't land simultaneously, causing a jump to max). Now it anchors to the first two-finger frame and maps proportionally.

2. Native zoom mapped the normalized 0..1 value linearly to the zoom ratio over the full min..max range. With large max zoom (up to 50x on iOS) and logarithmic perception, the useful range was crammed into the first few percent of finger travel. Now uses a geometric mapping (ratio = minZoom * (maxZoom / minZoom) ^ normalized) on Android and iOS so equal finger travel gives equal perceived zoom change, matching the native camera feel. setZoomToOneX is updated to the matching inverse.